### PR TITLE
ralph(#10): Add fixture-driven parser validation for at least one character save, one shared stash, and one stackable-material input that produce a deterministic account report.

### DIFF
--- a/progress.txt
+++ b/progress.txt
@@ -19,3 +19,11 @@ VERIFY: .\\scripts\\verify.ps1
 FILES:
  - test/backend-gateway.integration.test.mjs
 
+[2026-03-29 13:23:36 -04:00] TASK: Add fixture-driven parser validation for at least one character save, one shared stash, and one stackable-material input that produce a deterministic account report.
+ISSUE: #10 https://github.com/bhavinamin/d2r-wealth/issues/10
+BRANCH: task/10-add-fixture-driven-parser-validation-for-at-leas
+VERIFY: .\\scripts\\verify.ps1
+FILES:
+ - test/fixtures/
+ - test/parser-fixtures.test.mjs
+

--- a/test/fixtures/parser-account.fixture.json
+++ b/test/fixtures/parser-account.fixture.json
@@ -1,0 +1,168 @@
+{
+  "accountDirName": "fixture-account",
+  "reportImportedAt": "2026-03-29T16:00:00.000Z",
+  "character": {
+    "fileName": "FixtureSorc.d2s",
+    "name": "FixtureSorc",
+    "className": "Sorceress",
+    "level": 90,
+    "items": [
+      {
+        "template": "harlequin-crest",
+        "location": "equipped",
+        "equippedId": 1,
+        "x": 0,
+        "y": 0
+      }
+    ]
+  },
+  "sharedStash": {
+    "fileName": "SharedStashSoftCoreV2.d2i",
+    "pages": [
+      {
+        "name": "Valuables",
+        "isStackable": 0,
+        "items": [
+          {
+            "template": "harlequin-crest",
+            "location": "shared-stash",
+            "x": 0,
+            "y": 0
+          }
+        ]
+      },
+      {
+        "name": "Materials",
+        "isStackable": 1,
+        "items": [
+          {
+            "template": "jah-rune",
+            "location": "shared-stash",
+            "x": 1,
+            "y": 0,
+            "stackAmount": 2
+          },
+          {
+            "template": "ist-rune",
+            "location": "shared-stash",
+            "x": 2,
+            "y": 0,
+            "stackAmount": 4
+          },
+          {
+            "template": "ber-rune",
+            "location": "shared-stash",
+            "x": 3,
+            "y": 0,
+            "stackAmount": 0
+          }
+        ]
+      }
+    ]
+  },
+  "expectedReport": {
+    "importedAt": "2026-03-29T16:00:00.000Z",
+    "saveSetId": "15304a871e250089e79f0bbe06f82019b57c60c1fd2ec7cc0a8ef72b2ecbe8e7",
+    "totalHr": 3.1875,
+    "runeHr": 3,
+    "equippedHr": 0.0938,
+    "stashHr": 0,
+    "sharedHr": 3.0938,
+    "characters": [
+      {
+        "name": "FixtureSorc",
+        "className": "Sorceress",
+        "level": 90,
+        "ruleset": "LoD",
+        "equippedHr": 0.094,
+        "stashHr": 0
+      }
+    ],
+    "runeSummary": [
+      {
+        "name": "Jah",
+        "count": 2,
+        "looseCount": 2,
+        "totalHr": 2.5
+      },
+      {
+        "name": "Ist",
+        "count": 4,
+        "looseCount": 4,
+        "totalHr": 0.5
+      }
+    ],
+    "topCharacterStash": [],
+    "topInventory": [],
+    "topSharedStash": [
+      {
+        "id": "SharedStashSoftCoreV2.d2i-SharedStashSoftCoreV2.d2i page 1 item 1-Harlequin Crest",
+        "name": "Harlequin Crest",
+        "quantity": 2,
+        "owner": "SharedStashSoftCoreV2.d2i",
+        "location": "shared-stash",
+        "source": "SharedStashSoftCoreV2.d2i page 1 item 1",
+        "sheet": "UniqueSet Market",
+        "valueHr": 0.09375,
+        "tradeValue": "Mal",
+        "matchedBy": "exact"
+      }
+    ],
+    "allValuedItems": [
+      {
+        "id": "SharedStashSoftCoreV2.d2i-SharedStashSoftCoreV2.d2i materials 1-Jah Rune",
+        "name": "Jah Rune",
+        "quantity": 2,
+        "owner": "SharedStashSoftCoreV2.d2i",
+        "location": "shared-stash",
+        "source": "SharedStashSoftCoreV2.d2i materials 1",
+        "valueHr": 2.5,
+        "matchedBy": "token"
+      },
+      {
+        "id": "SharedStashSoftCoreV2.d2i-SharedStashSoftCoreV2.d2i materials 2-Ist Rune",
+        "name": "Ist Rune",
+        "quantity": 4,
+        "owner": "SharedStashSoftCoreV2.d2i",
+        "location": "shared-stash",
+        "source": "SharedStashSoftCoreV2.d2i materials 2",
+        "valueHr": 0.5,
+        "matchedBy": "token"
+      },
+      {
+        "id": "FixtureSorc-FixtureSorc equipped 1-Harlequin Crest",
+        "name": "Harlequin Crest",
+        "quantity": 1,
+        "owner": "FixtureSorc",
+        "location": "equipped",
+        "source": "FixtureSorc equipped 1",
+        "sheet": "UniqueSet Market",
+        "valueHr": 0.09375,
+        "tradeValue": "Mal",
+        "matchedBy": "exact"
+      },
+      {
+        "id": "SharedStashSoftCoreV2.d2i-SharedStashSoftCoreV2.d2i page 1 item 1-Harlequin Crest",
+        "name": "Harlequin Crest",
+        "quantity": 2,
+        "owner": "SharedStashSoftCoreV2.d2i",
+        "location": "shared-stash",
+        "source": "SharedStashSoftCoreV2.d2i page 1 item 1",
+        "sheet": "UniqueSet Market",
+        "valueHr": 0.09375,
+        "tradeValue": "Mal",
+        "matchedBy": "exact"
+      }
+    ],
+    "unmatchedItems": [],
+    "snapshot": {
+      "importedAt": "2026-03-29T16:00:00.000Z",
+      "totalHr": 3.1875,
+      "runeHr": 3,
+      "equippedHr": 0.0938,
+      "stashHr": 0,
+      "sharedHr": 3.0938,
+      "characterCount": 1
+    }
+  }
+}

--- a/test/parser-fixtures.test.mjs
+++ b/test/parser-fixtures.test.mjs
@@ -1,0 +1,491 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import fixture from "./fixtures/parser-account.fixture.json" with { type: "json" };
+import { buildGatewayReport } from "../gateway/report.mjs";
+import { write as writeCharacter, setConstantData } from "@d2runewizard/d2s";
+import { write as writeStash } from "@d2runewizard/d2s/lib/d2/stash.js";
+import { constants as constants96 } from "@d2runewizard/d2s/lib/data/versions/96_constant_data.js";
+import { constants as constants105 } from "@d2runewizard/d2s/lib/data/versions/105_constant_data.js";
+
+setConstantData(96, constants96);
+setConstantData(105, constants105);
+
+const menuAppearanceParts = [
+  "head",
+  "torso",
+  "legs",
+  "right_arm",
+  "left_arm",
+  "right_hand",
+  "left_hand",
+  "shield",
+  "special1",
+  "special2",
+  "special3",
+  "special4",
+  "special5",
+  "special6",
+  "special7",
+  "special8",
+];
+
+const actQuestNames = {
+  act_i: [
+    "den_of_evil",
+    "sisters_burial_grounds",
+    "tools_of_the_trade",
+    "the_search_for_cain",
+    "the_forgotten_tower",
+    "sisters_to_the_slaughter",
+  ],
+  act_ii: [
+    "radaments_lair",
+    "the_horadric_staff",
+    "tainted_sun",
+    "arcane_sanctuary",
+    "the_summoner",
+    "the_seven_tombs",
+  ],
+  act_iii: [
+    "lam_esens_tome",
+    "khalims_will",
+    "blade_of_the_old_religion",
+    "the_golden_bird",
+    "the_blackened_temple",
+    "the_guardian",
+  ],
+  act_iv: ["the_fallen_angel", "terrors_end", "hellforge"],
+  act_v: [
+    "siege_on_harrogath",
+    "rescue_on_mount_arreat",
+    "prison_of_ice",
+    "betrayal_of_harrogath",
+    "rite_of_passage",
+    "eve_of_destruction",
+  ],
+};
+
+const waypointNames = {
+  act_i: [
+    "rogue_encampement",
+    "cold_plains",
+    "stony_field",
+    "dark_woods",
+    "black_marsh",
+    "outer_cloister",
+    "jail_lvl_1",
+    "inner_cloister",
+    "catacombs_lvl_2",
+  ],
+  act_ii: [
+    "lut_gholein",
+    "sewers_lvl_2",
+    "dry_hills",
+    "halls_of_the_dead_lvl_2",
+    "far_oasis",
+    "lost_city",
+    "palace_cellar_lvl_1",
+    "arcane_sanctuary",
+    "canyon_of_the_magi",
+  ],
+  act_iii: [
+    "kurast_docks",
+    "spider_forest",
+    "great_marsh",
+    "flayer_jungle",
+    "lower_kurast",
+    "kurast_bazaar",
+    "upper_kurast",
+    "travincal",
+    "durance_of_hate_lvl_2",
+  ],
+  act_iv: ["the_pandemonium_fortress", "city_of_the_damned", "river_of_flame"],
+  act_v: [
+    "harrogath",
+    "frigid_highlands",
+    "arreat_plateau",
+    "crystalline_passage",
+    "halls_of_pain",
+    "glacial_trail",
+    "frozen_tundra",
+    "the_ancients_way",
+    "worldstone_keep_lvl_2",
+  ],
+};
+
+const npcNames = [
+  "warriv_act_ii",
+  "charsi",
+  "warriv_act_i",
+  "kashya",
+  "akara",
+  "gheed",
+  "greiz",
+  "jerhyn",
+  "meshif_act_ii",
+  "geglash",
+  "lysnader",
+  "fara",
+  "drogan",
+  "alkor",
+  "hratli",
+  "ashera",
+  "cain_act_iii",
+  "elzix",
+  "malah",
+  "anya",
+  "natalya",
+  "meshif_act_iii",
+  "ormus",
+  "cain_act_v",
+  "qualkehk",
+  "nihlathak",
+];
+
+const fixedImportedAt = fixture.reportImportedAt;
+const RealDate = Date;
+
+const createQuest = () => ({
+  is_completed: false,
+  is_requirement_completed: false,
+  is_received: false,
+  unk3: false,
+  unk4: false,
+  unk5: false,
+  unk6: false,
+  consumed_scroll: false,
+  unk8: false,
+  unk9: false,
+  unk10: false,
+  unk11: false,
+  closed: false,
+  done_recently: false,
+  unk14: false,
+  unk15: false,
+});
+
+const createQuests = () =>
+  Object.fromEntries(
+    Object.entries(actQuestNames).map(([actName, quests]) => [
+      actName,
+      {
+        introduced: false,
+        ...Object.fromEntries(quests.map((questName) => [questName, createQuest()])),
+        completed: false,
+      },
+    ]),
+  );
+
+const createWaypoints = () =>
+  Object.fromEntries(
+    ["normal", "nm", "hell"].map((difficulty) => [
+      difficulty,
+      Object.fromEntries(
+        Object.entries(waypointNames).map(([actName, entries]) => [
+          actName,
+          Object.fromEntries(entries.map((name) => [name, false])),
+        ]),
+      ),
+    ]),
+  );
+
+const createNpcs = () =>
+  Object.fromEntries(
+    ["normal", "nm", "hell"].map((difficulty) => [
+      difficulty,
+      Object.fromEntries(npcNames.map((name) => [name, { intro: false, congrats: false }])),
+    ]),
+  );
+
+const createMenuAppearance = () =>
+  Object.fromEntries(menuAppearanceParts.map((part) => [part, { graphic: 0, tint: 0 }]));
+
+const createAttributes = (className, level) => {
+  const classData = constants96.classes.find((entry) => entry?.n === className)?.a;
+  assert.ok(classData, `Missing class constants for ${className}`);
+
+  return {
+    strength: Number(classData.str),
+    energy: Number(classData.int),
+    dexterity: Number(classData.dex),
+    vitality: Number(classData.vit),
+    current_hp: Number(classData.vit) + Number(classData.hpadd),
+    max_hp: Number(classData.vit) + Number(classData.hpadd),
+    current_mana: Number(classData.int),
+    max_mana: Number(classData.int),
+    current_stamina: Number(classData.stam),
+    max_stamina: Number(classData.stam),
+    level,
+  };
+};
+
+const createSkills = (className) => {
+  const classCode = constants96.classes.find((entry) => entry?.n === className)?.c;
+  assert.ok(classCode, `Missing class code for ${className}`);
+
+  return constants96.skills
+    .filter((skill) => skill?.c === classCode)
+    .map((skill, index) => ({
+      id: index,
+      name: skill.s,
+      points: 0,
+    }));
+};
+
+const resolveLocation = (location) => {
+  if (location === "equipped") {
+    return { location_id: 1, alt_position_id: 0 };
+  }
+
+  if (location === "inventory") {
+    return { location_id: 0, alt_position_id: 1 };
+  }
+
+  return { location_id: 0, alt_position_id: 5 };
+};
+
+const baseItem = ({ type, typeName, quality = 2, itemVersion = "101", x = 0, y = 0, location, equippedId = 0 }) => {
+  const { location_id, alt_position_id } = resolveLocation(location);
+
+  return {
+    identified: 1,
+    socketed: 0,
+    new: 0,
+    is_ear: 0,
+    starter_item: 0,
+    simple_item: 0,
+    ethereal: 0,
+    personalized: 0,
+    personalized_name: "",
+    given_runeword: 0,
+    version: itemVersion,
+    location_id,
+    equipped_id: equippedId,
+    position_x: x,
+    position_y: y,
+    alt_position_id,
+    type,
+    type_id: 0,
+    type_name: typeName,
+    quest_difficulty: 0,
+    nr_of_items_in_sockets: 0,
+    id: 100000 + x * 100 + y,
+    level: 90,
+    quality,
+    multiple_pictures: 0,
+    picture_id: 0,
+    class_specific: 0,
+    low_quality_id: 0,
+    timestamp: 0,
+    ear_attributes: { class: 0, level: 0, name: "" },
+    defense_rating: 0,
+    max_durability: 0,
+    current_durability: 0,
+    total_nr_of_sockets: 0,
+    quantity: 0,
+    magic_prefix: 0,
+    magic_prefix_name: "",
+    magic_suffix: 0,
+    magic_suffix_name: "",
+    runeword_id: 0,
+    runeword_name: "",
+    runeword_attributes: [],
+    set_id: 0,
+    set_name: "",
+    set_list_count: 0,
+    set_attributes: [],
+    set_attributes_num_req: 0,
+    set_attributes_ids_req: 0,
+    rare_name: "",
+    rare_name2: "",
+    magical_name_ids: [],
+    unique_id: 0,
+    unique_name: "",
+    magic_attributes: [],
+    combined_magic_attributes: [],
+    socketed_items: [],
+    base_damage: { mindam: 0, maxdam: 0, twohandmindam: 0, twohandmaxdam: 0 },
+    reqstr: 0,
+    reqdex: 0,
+    inv_width: 1,
+    inv_height: 1,
+    inv_file: 0,
+    inv_transform: 0,
+    transform_color: "",
+    item_quality: 0,
+    file_index: 0,
+    auto_affix_id: 0,
+    _unknown_data: {},
+    rare_name_id: 0,
+    rare_name_id2: 0,
+    displayed_magic_attributes: [],
+    displayed_runeword_attributes: [],
+    displayed_combined_magic_attributes: [],
+  };
+};
+
+const buildItem = (spec, targetVersion) => {
+  switch (spec.template) {
+    case "harlequin-crest":
+      return {
+        ...baseItem({
+          type: "uap",
+          typeName: "Shako",
+          quality: 7,
+          itemVersion: targetVersion > 0x61 ? "101" : "101",
+          x: spec.x,
+          y: spec.y,
+          location: spec.location,
+          equippedId: spec.equippedId ?? 0,
+        }),
+        defense_rating: 141,
+        max_durability: 12,
+        current_durability: 12,
+        unique_id: 248,
+        unique_name: "Harlequin Crest",
+      };
+    case "ber-rune":
+      return buildMaterialItem(spec, targetVersion, "r30", "Ber Rune");
+    case "jah-rune":
+      return buildMaterialItem(spec, targetVersion, "r31", "Jah Rune");
+    case "ist-rune":
+      return buildMaterialItem(spec, targetVersion, "r24", "Ist Rune");
+    case "key-of-hatred":
+      return buildMaterialItem(spec, targetVersion, "pk2", "Key of Hate");
+    case "key-of-terror":
+      return buildMaterialItem(spec, targetVersion, "pk1", "Key of Terror");
+    default:
+      throw new Error(`Unsupported fixture item template: ${spec.template}`);
+  }
+};
+
+const buildMaterialItem = (spec, targetVersion, type, typeName) => {
+  const item = baseItem({
+    type,
+    typeName,
+    itemVersion: targetVersion > 0x61 ? "101" : "101",
+    x: spec.x,
+    y: spec.y,
+    location: spec.location,
+    equippedId: spec.equippedId ?? 0,
+  });
+
+  if (typeof spec.stackAmount === "number") {
+    item._unknown_data.chest_stackable = 1;
+    item.amount_in_shared_stash = spec.stackAmount;
+  }
+
+  return item;
+};
+
+const createCharacterFile = async (saveDir) => {
+  const character = fixture.character;
+  const payload = {
+    header: {
+      identifier: "aa55aa55",
+      checksum: "00000000",
+      name: character.name,
+      status: { expansion: true, died: false, hardcore: false, ladder: false },
+      class: character.className,
+      created: 0,
+      last_played: 0,
+      menu_appearance: createMenuAppearance(),
+      left_skill: "Attack",
+      right_skill: "Attack",
+      left_swap_skill: "Attack",
+      right_swap_skill: "Attack",
+      merc_id: "0",
+      assigned_skills: [],
+      quests_normal: createQuests(),
+      quests_nm: createQuests(),
+      quests_hell: createQuests(),
+      waypoints: createWaypoints(),
+      npcs: createNpcs(),
+      version: 96,
+      filesize: 0,
+      active_arms: 0,
+      progression: 0,
+      level: character.level,
+      difficulty: { Normal: 0, Nightmare: 0, Hell: 0 },
+      map_id: 0,
+      dead_merc: 0,
+      merc_name_id: 0,
+      merc_type: 0,
+      merc_experience: 0,
+    },
+    attributes: createAttributes(character.className, character.level),
+    item_bonuses: [],
+    skills: createSkills(character.className),
+    items: character.items.map((item) => buildItem(item, 96)),
+    corpse_items: [],
+    merc_items: [],
+    golem_item: null,
+    demon: null,
+    is_dead: 0,
+  };
+
+  const bytes = await writeCharacter(payload, constants96, { disableItemEnhancements: true });
+  await fs.writeFile(path.join(saveDir, character.fileName), Buffer.from(bytes));
+};
+
+const createSharedStashFile = async (saveDir) => {
+  const stash = fixture.sharedStash;
+  const payload = {
+    version: "105",
+    type: 0,
+    pageCount: stash.pages.length,
+    sharedGold: 0,
+    hardcore: false,
+    pages: stash.pages.map((page) => ({
+      name: page.name,
+      type: 0,
+      isStackable: page.isStackable,
+      items: page.items.map((item) => buildItem(item, 0x69)),
+    })),
+  };
+
+  const bytes = await writeStash(payload, constants105, 0x69, { disableItemEnhancements: true });
+  await fs.writeFile(path.join(saveDir, stash.fileName), Buffer.from(bytes));
+};
+
+const withFixedDate = async (fn) => {
+  class MockDate extends RealDate {
+    constructor(...args) {
+      super(args.length ? args[0] : fixedImportedAt);
+    }
+
+    static now() {
+      return new RealDate(fixedImportedAt).valueOf();
+    }
+
+    static parse(value) {
+      return RealDate.parse(value);
+    }
+
+    static UTC(...args) {
+      return RealDate.UTC(...args);
+    }
+  }
+
+  globalThis.Date = MockDate;
+  try {
+    return await fn();
+  } finally {
+    globalThis.Date = RealDate;
+  }
+};
+
+test("fixture-driven gateway report stays deterministic across character, shared stash, and stackable materials", async () => {
+  const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "d2-wealth-parser-fixtures-"));
+  const saveDir = path.join(tempRoot, fixture.accountDirName);
+  await fs.mkdir(saveDir, { recursive: true });
+
+  await createCharacterFile(saveDir);
+  await createSharedStashFile(saveDir);
+
+  const report = await withFixedDate(() => buildGatewayReport(saveDir));
+  assert.deepEqual(report, fixture.expectedReport);
+});


### PR DESCRIPTION
## Summary
- Implement PRD task: Add fixture-driven parser validation for at least one character save, one shared stash, and one stackable-material input that produce a deterministic account report.

## Tracking
- Closes #10
- Local verification: `.\\scripts\\verify.ps1`
- Merge rule: resolve GitHub review findings before merge