### PR TITLE
Fix Ralph loop subprocess capture

### DIFF
--- a/scripts/ralph-loop.ps1
+++ b/scripts/ralph-loop.ps1
@@ -75,7 +75,12 @@ function Invoke-LoggedPowerShellFile([string]$ScriptPath, [string[]]$Arguments, 
     $joinedArguments = if ($Arguments -and $Arguments.Count -gt 0) { $Arguments -join " " } else { "" }
     $command = "powershell -ExecutionPolicy Bypass -File `"$ScriptPath`" $joinedArguments".Trim()
     Write-Host "Running: $command"
-    & powershell -ExecutionPolicy Bypass -File $ScriptPath @Arguments 2>&1 | Tee-Object -FilePath $OutputFile
+    $cmdCommand = "powershell -ExecutionPolicy Bypass -File ""$ScriptPath"""
+    if ($joinedArguments) {
+        $cmdCommand += " $joinedArguments"
+    }
+
+    & cmd.exe /d /s /c "$cmdCommand 2>&1" | Tee-Object -FilePath $OutputFile
     return $LASTEXITCODE
 }
 


### PR DESCRIPTION
## Summary
- capture ralph-once subprocess output as plain text in the loop supervisor
- avoid PowerShell treating git fetch stderr chatter as a terminating error

## Testing
- PowerShell parse check for scripts/ralph-loop.ps1
- git diff --check