### PR TITLE
ralph(#25): Make gateway status reporting explicit for save validation, pairing state, sync state, and last error so users can tell why the dashboard is stale.

### DIFF
--- a/gateway/service.mjs
+++ b/gateway/service.mjs
@@ -9,6 +9,122 @@ const ALLOWED_EXTENSIONS = new Set([".d2s", ".d2i", ".sss", ".cst"]);
 const CHANGE_DEBOUNCE_MS = 1500;
 const MAX_SYNC_LOG_ENTRIES = 25;
 
+const deriveGatewayStatusSummary = ({
+  saveValidation,
+  syncToken,
+  lastBackendSyncAt,
+  lastBackendSyncError,
+  lastSuccessfulAccountUpdateAt,
+  syncInFlight,
+}) => {
+  const saveChecked = Boolean(saveValidation?.checkedAt);
+  const saveValid = Boolean(saveValidation?.valid);
+  const saveMessage = saveValidation?.message ?? "Waiting for save scan.";
+
+  const save = saveChecked
+    ? saveValid
+      ? {
+          state: "ready",
+          label: "Ready",
+          detail: saveMessage,
+        }
+      : {
+          state: "attention",
+          label: "Needs Attention",
+          detail: saveMessage,
+        }
+    : {
+        state: "checking",
+        label: "Checking",
+        detail: saveMessage,
+      };
+
+  const pairing = syncToken
+    ? {
+        state: "paired",
+        label: "Paired",
+        detail: "This PC has a gateway sync token and can upload account snapshots.",
+      }
+    : saveValid
+      ? {
+          state: "ready",
+          label: "Ready To Pair",
+          detail: "Discord sign-in can open now so you can approve pairing for this PC.",
+        }
+      : {
+          state: "blocked",
+          label: "Blocked",
+          detail: "Fix save validation before pairing this PC to your D2 Wealth account.",
+        };
+
+  let sync;
+  if (!syncToken) {
+    sync = {
+      state: "not-paired",
+      label: "Not Paired",
+      detail: "No gateway sync token is available yet, so uploads cannot start.",
+    };
+  } else if (syncInFlight) {
+    sync = {
+      state: "syncing",
+      label: "Syncing",
+      detail: "A gateway upload is in progress.",
+    };
+  } else if (!saveValid) {
+    sync = {
+      state: "blocked",
+      label: "Blocked",
+      detail: "Save validation is failing, so the dashboard will stay stale until this folder is fixed.",
+    };
+  } else if (lastBackendSyncError) {
+    sync = {
+      state: "error",
+      label: "Error",
+      detail: lastBackendSyncError,
+    };
+  } else if (lastBackendSyncAt) {
+    sync = {
+      state: "synced",
+      label: "Synced",
+      detail: `Last upload reached the backend at ${lastBackendSyncAt}.`,
+    };
+  } else {
+    sync = {
+      state: "pending",
+      label: "Pending First Sync",
+      detail: "Pairing is complete, but the first successful upload has not finished yet.",
+    };
+  }
+
+  const lastError = lastBackendSyncError
+    ? {
+        scope: "sync",
+        message: lastBackendSyncError,
+        occurredAt: lastBackendSyncAt ?? null,
+      }
+    : saveChecked && !saveValid
+      ? {
+          scope: "save-validation",
+          message: saveMessage,
+          occurredAt: saveValidation.checkedAt,
+        }
+      : null;
+
+  return {
+    save,
+    pairing,
+    sync,
+    lastError,
+    dashboardFreshness: {
+      state: lastSuccessfulAccountUpdateAt ? "fresh" : "stale",
+      label: lastSuccessfulAccountUpdateAt ? "Last Upload Recorded" : "No Successful Upload Yet",
+      detail: lastSuccessfulAccountUpdateAt
+        ? `Backend account data was last updated at ${lastSuccessfulAccountUpdateAt}.`
+        : "The backend does not have a successful upload from this gateway yet.",
+    },
+  };
+};
+
 export class GatewayService {
   constructor(options = {}) {
     this.settingsPath = options.settingsPath;
@@ -56,14 +172,25 @@ export class GatewayService {
   }
 
   status() {
+    const files = this.listSaveFiles();
+    const statusSummary = deriveGatewayStatusSummary({
+      saveValidation: this.lastSaveValidation,
+      syncToken: this.settings.syncToken,
+      lastBackendSyncAt: this.lastBackendSyncAt,
+      lastBackendSyncError: this.lastBackendSyncError,
+      lastSuccessfulAccountUpdateAt: this.lastSuccessfulAccountUpdateAt,
+      syncInFlight: Boolean(this.syncInFlight),
+    });
+
     return {
       ...this.settings,
       running: Boolean(this.server?.listening),
-      files: this.listSaveFiles(),
+      files,
       saveValidation: this.lastSaveValidation,
       lastBackendSyncAt: this.lastBackendSyncAt,
       lastBackendSyncError: this.lastBackendSyncError,
       lastSuccessfulAccountUpdateAt: this.lastSuccessfulAccountUpdateAt,
+      statusSummary,
       syncLog: this.syncLog,
       watchedAt: new Date().toISOString(),
     };

--- a/gateway/settings.html
+++ b/gateway/settings.html
@@ -90,6 +90,16 @@
         color: #89df9d;
       }
 
+      .state-pill.warning {
+        background: rgba(201, 137, 54, 0.22);
+        color: #f4d8a7;
+      }
+
+      .state-pill.error {
+        background: rgba(163, 51, 44, 0.22);
+        color: #ffb0a7;
+      }
+
       .state-pill.idle {
         background: rgba(255, 255, 255, 0.08);
         color: rgba(243, 237, 225, 0.78);
@@ -263,9 +273,15 @@
         margin-top: 5px;
         font-size: 0.9rem;
         color: #f4d8a7;
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
+        line-height: 1.35;
+      }
+
+      .meta-card small {
+        display: block;
+        margin-top: 6px;
+        font-size: 0.76rem;
+        line-height: 1.4;
+        color: rgba(243, 237, 225, 0.68);
       }
 
       .grow {
@@ -365,16 +381,51 @@
       let autoStartDirty = false;
 
       const hasUnsavedChanges = () => saveDirDirty || autoStartDirty;
+      const defaultSaveValidation = { valid: false, message: "Choose a save folder." };
+      const fallbackStatusSummary = {
+        save: { state: "checking", label: "Checking", detail: "Waiting for save scan." },
+        pairing: { state: "blocked", label: "Blocked", detail: "Choose a valid save folder before pairing." },
+        sync: { state: "not-paired", label: "Not Paired", detail: "No gateway sync token is available yet." },
+        lastError: null,
+        dashboardFreshness: {
+          state: "stale",
+          label: "No Successful Upload Yet",
+          detail: "The backend does not have a successful upload from this gateway yet.",
+        },
+      };
+
+      const escapeHtml = (value) =>
+        String(value ?? "")
+          .replaceAll("&", "&amp;")
+          .replaceAll("<", "&lt;")
+          .replaceAll(">", "&gt;")
+          .replaceAll('"', "&quot;")
+          .replaceAll("'", "&#39;");
+
+      const summarizeStatus = (status) => status.statusSummary ?? fallbackStatusSummary;
+
+      const pillClassForState = (state) => {
+        if (state === "synced" || state === "paired" || state === "ready" || state === "fresh") {
+          return "connected";
+        }
+        if (state === "error" || state === "attention") {
+          return "error";
+        }
+        if (state === "blocked" || state === "syncing" || state === "pending") {
+          return "warning";
+        }
+        return "idle";
+      };
 
       const setPairingMessage = (status, { unsavedChanges = hasUnsavedChanges() } = {}) => {
-        const linked = Boolean(status.syncToken);
-        const saveValidation = status.saveValidation ?? { valid: false, message: "Choose a save folder." };
-        const saveReady = Boolean(saveValidation.valid);
+        const summary = summarizeStatus(status);
+        const saveReady = summary.save.state === "ready";
+        const paired = summary.pairing.state === "paired";
 
-        if (linked && saveReady) {
+        if (paired && summary.sync.state === "synced") {
           return "This PC is linked to your D2 Wealth account. Leave the gateway running and it will keep syncing in the background.";
         }
-        if (linked) {
+        if (paired) {
           return "This PC is linked, but the save folder still needs attention before sync can recover.";
         }
         if (unsavedChanges) {
@@ -387,8 +438,9 @@
       };
 
       const renderSetupChecklist = (status, { unsavedChanges = hasUnsavedChanges() } = {}) => {
-        const linked = Boolean(status.syncToken);
-        const saveReady = Boolean(status.saveValidation?.valid);
+        const summary = summarizeStatus(status);
+        const paired = summary.pairing.state === "paired";
+        const saveReady = summary.save.state === "ready";
         for (const item of setupList.querySelectorAll("[data-step]")) {
           const step = item.getAttribute("data-step");
           let complete = false;
@@ -398,11 +450,11 @@
             complete = saveReady && !unsavedChanges;
             active = !complete;
           } else if (step === "auth") {
-            complete = linked;
+            complete = paired;
             active = !complete && saveReady && !unsavedChanges;
           } else if (step === "sync") {
-            complete = linked && Boolean(status.lastBackendSyncAt) && !status.lastBackendSyncError;
-            active = linked && !complete;
+            complete = summary.sync.state === "synced";
+            active = paired && !complete;
           }
 
           item.classList.toggle("is-complete", complete);
@@ -411,39 +463,55 @@
       };
 
       const renderStatus = (status) => {
-        const linked = Boolean(status.syncToken);
-        const syncConnected = Boolean(status.syncToken && status.lastBackendSyncAt && !status.lastBackendSyncError);
-        const saveValidation = status.saveValidation ?? { valid: false, message: "Choose a save folder." };
-        syncPill.textContent = syncConnected ? "Connected" : linked ? "Linked" : "Idle";
-        syncPill.className = `state-pill ${linked ? "connected" : "idle"}`;
+        const summary = summarizeStatus(status);
+        const paired = summary.pairing.state === "paired";
+        const saveValidation = status.saveValidation ?? defaultSaveValidation;
+        syncPill.textContent = summary.sync.label;
+        syncPill.className = `state-pill ${pillClassForState(summary.sync.state)}`;
 
         saveStatus.textContent = saveValidation.message ?? "Choose a save folder.";
         saveStatus.className = `save-status ${saveValidation.valid ? "valid" : "invalid"}`;
 
-        pairGateway.classList.toggle("hidden", linked);
-        linkedPanel.classList.toggle("hidden", !linked);
+        pairGateway.classList.toggle("hidden", paired);
+        linkedPanel.classList.toggle("hidden", !paired);
         disconnectGateway.classList.toggle("hidden", !status.syncToken);
         pairGateway.disabled = !saveValidation.valid || hasUnsavedChanges();
         pairCopy.style.color = "";
         pairCopy.textContent = setPairingMessage(status);
         renderSetupChecklist(status);
 
+        const lastErrorLabel = summary.lastError ? summary.lastError.scope : "clear";
+        const lastErrorMessage = summary.lastError?.message ?? "No recent blocking error.";
         statusGrid.innerHTML = `
           <article class="meta-card">
-            <span>Gateway</span>
-            <strong>${status.running ? "Running" : "Stopped"}</strong>
+            <span>Save Validation</span>
+            <strong>${escapeHtml(summary.save.label)}</strong>
+            <small>${escapeHtml(summary.save.detail)}</small>
           </article>
           <article class="meta-card">
-            <span>Sync</span>
-            <strong>${syncConnected ? "Connected" : linked ? "Linked" : "Not linked"}</strong>
+            <span>Pairing State</span>
+            <strong>${escapeHtml(summary.pairing.label)}</strong>
+            <small>${escapeHtml(summary.pairing.detail)}</small>
           </article>
           <article class="meta-card">
-            <span>Files Seen</span>
-            <strong>${status.files.length}</strong>
+            <span>Sync State</span>
+            <strong>${escapeHtml(summary.sync.label)}</strong>
+            <small>${escapeHtml(summary.sync.detail)}</small>
           </article>
           <article class="meta-card">
-            <span>Last Sync</span>
-            <strong>${status.lastBackendSyncAt ?? status.lastBackendSyncError ?? (linked ? "Pending first sync" : "Never")}</strong>
+            <span>Last Error</span>
+            <strong>${escapeHtml(lastErrorLabel)}</strong>
+            <small>${escapeHtml(lastErrorMessage)}</small>
+          </article>
+          <article class="meta-card">
+            <span>Last Account Update</span>
+            <strong>${escapeHtml(status.lastSuccessfulAccountUpdateAt ?? "Never")}</strong>
+            <small>${escapeHtml(summary.dashboardFreshness.detail)}</small>
+          </article>
+          <article class="meta-card">
+            <span>Gateway Runtime</span>
+            <strong>${escapeHtml(status.running ? "Running" : "Stopped")}</strong>
+            <small>${escapeHtml(`${status.files.length} tracked save file${status.files.length === 1 ? "" : "s"} in the selected folder.`)}</small>
           </article>
         `;
       };
@@ -461,12 +529,12 @@
 
       saveDir.addEventListener("input", () => {
         saveDirDirty = true;
-        renderStatus(window.__lastGatewayStatus ?? { saveValidation: { valid: false, message: "Choose a save folder." }, files: [] });
+        renderStatus(window.__lastGatewayStatus ?? { saveValidation: defaultSaveValidation, files: [] });
       });
 
       autoStart.addEventListener("change", () => {
         autoStartDirty = true;
-        renderStatus(window.__lastGatewayStatus ?? { saveValidation: { valid: false, message: "Choose a save folder." }, files: [] });
+        renderStatus(window.__lastGatewayStatus ?? { saveValidation: defaultSaveValidation, files: [] });
       });
 
       const persistPendingSettings = async () => {
@@ -495,7 +563,7 @@
         if (nextSaveDir) {
           saveDir.value = nextSaveDir;
           saveDirDirty = true;
-          renderStatus(window.__lastGatewayStatus ?? { saveValidation: { valid: false, message: "Choose a save folder." }, files: [] });
+          renderStatus(window.__lastGatewayStatus ?? { saveValidation: defaultSaveValidation, files: [] });
         }
       });
 

--- a/progress.txt
+++ b/progress.txt
@@ -60,3 +60,12 @@ FILES:
  - gateway/tray.mjs
  - test/backend-gateway.integration.test.mjs
 
+[2026-03-29 14:01:20 -04:00] TASK: Make gateway status reporting explicit for save validation, pairing state, sync state, and last error so users can tell why the dashboard is stale.
+ISSUE: #25 https://github.com/bhavinamin/d2r-wealth/issues/25
+BRANCH: task/25-make-gateway-status-reporting-explicit-for-save
+VERIFY: .\\scripts\\verify.ps1
+FILES:
+ - gateway/service.mjs
+ - gateway/settings.html
+ - test/backend-gateway.integration.test.mjs
+

--- a/test/backend-gateway.integration.test.mjs
+++ b/test/backend-gateway.integration.test.mjs
@@ -162,6 +162,71 @@ test("pairing issues a token only after approval and consumes the pairing on fir
   assert.equal(consumedClaim.status, "consumed");
 });
 
+test("gateway status summary reports explicit save, pairing, sync, and last-error states", async () => {
+  const invalidService = new GatewayService({
+    settings: {
+      host: "127.0.0.1",
+      port: 3188,
+      saveDir: path.join(tempRoot, "missing-saves"),
+      autoStart: false,
+      dashboardUrl: "http://127.0.0.1:4173",
+      backendUrl: "http://127.0.0.1:9999",
+      accountId: "account-missing",
+      clientId: "desktop-missing",
+      syncToken: "",
+    },
+  });
+
+  await invalidService.refreshSaveValidation();
+  const invalidStatus = invalidService.status();
+  assert.equal(invalidStatus.statusSummary.save.state, "attention");
+  assert.equal(invalidStatus.statusSummary.pairing.state, "blocked");
+  assert.equal(invalidStatus.statusSummary.sync.state, "not-paired");
+  assert.equal(invalidStatus.statusSummary.lastError?.scope, "save-validation");
+  assert.match(String(invalidStatus.statusSummary.lastError?.message), /does not exist/i);
+
+  const validSaveDir = path.join(tempRoot, "status-ready");
+  fs.mkdirSync(validSaveDir, { recursive: true });
+  fs.writeFileSync(path.join(validSaveDir, "hero.d2s"), "fixture", "utf8");
+
+  const readyService = new GatewayService({
+    settings: {
+      host: "127.0.0.1",
+      port: 3189,
+      saveDir: validSaveDir,
+      autoStart: false,
+      dashboardUrl: "http://127.0.0.1:4173",
+      backendUrl: "http://127.0.0.1:9999",
+      accountId: "account-ready",
+      clientId: "desktop-ready",
+      syncToken: "",
+    },
+  });
+
+  readyService.buildReport = async () => ({
+    importedAt: "2026-03-29T12:00:00.000Z",
+    totalHr: 1,
+    characters: [{ name: "Ready", className: "Sorceress", level: 90, totalHr: 1 }],
+    snapshot: {
+      totalHr: 1,
+      equippedHr: 0.25,
+      runeHr: 0.25,
+      sharedHr: 0.25,
+      stashHr: 0.25,
+      characterCount: 1,
+      capturedAt: "2026-03-29T12:00:00.000Z",
+    },
+    topItems: [],
+  });
+
+  await readyService.refreshSaveValidation();
+  const readyStatus = readyService.status();
+  assert.equal(readyStatus.statusSummary.save.state, "ready");
+  assert.equal(readyStatus.statusSummary.pairing.state, "ready");
+  assert.equal(readyStatus.statusSummary.sync.state, "not-paired");
+  assert.equal(readyStatus.statusSummary.lastError, null);
+});
+
 test("gateway sync covers token-based ingest, latest/history reads, and disconnect cleanup", async (t) => {
   const ctx = await loadIntegrationContext("sync");
   t.after(ctx.close);
@@ -204,6 +269,11 @@ test("gateway sync covers token-based ingest, latest/history reads, and disconne
   assert.match(String(service.lastBackendSyncAt), /^\d{4}-\d{2}-\d{2}T/);
   assert.equal(service.lastBackendSyncError, null);
   assert.match(String(service.lastSuccessfulAccountUpdateAt), /^\d{4}-\d{2}-\d{2}T/);
+  const syncedStatus = service.status();
+  assert.equal(syncedStatus.statusSummary.save.state, "ready");
+  assert.equal(syncedStatus.statusSummary.pairing.state, "paired");
+  assert.equal(syncedStatus.statusSummary.sync.state, "synced");
+  assert.equal(syncedStatus.statusSummary.lastError, null);
   assert.equal(service.syncLog[0].event, "ingest-response");
   assert.equal(service.syncLog[0].outcome, "accepted");
   assert.equal(service.syncLog[0].lastSuccessfulAccountUpdateAt, service.lastSuccessfulAccountUpdateAt);
@@ -264,6 +334,12 @@ test("gateway sync covers token-based ingest, latest/history reads, and disconne
   assert.equal(service.syncLog[0].lastSuccessfulAccountUpdateAt, latestBody.lastSuccessfulAccountUpdateAt);
   assert.equal(service.syncLog[1].event, "ingest-attempt");
   assert.equal(service.syncLog[1].outcome, "attempted");
+  const rejectedStatus = service.status();
+  assert.equal(rejectedStatus.statusSummary.save.state, "ready");
+  assert.equal(rejectedStatus.statusSummary.pairing.state, "paired");
+  assert.equal(rejectedStatus.statusSummary.sync.state, "error");
+  assert.equal(rejectedStatus.statusSummary.lastError?.scope, "sync");
+  assert.equal(rejectedStatus.statusSummary.lastError?.message, "Backend ingest failed with 401");
 
   const { response: revokedIngestResponse, body: revokedIngestBody } = await fetchJson(`${ctx.backendBaseUrl}/api/ingest`, {
     method: "POST",


### PR DESCRIPTION
## Summary
- Implement PRD task: Make gateway status reporting explicit for save validation, pairing state, sync state, and last error so users can tell why the dashboard is stale.

## Tracking
- Closes #25
- Local verification: `.\\scripts\\verify.ps1`
- Merge rule: resolve GitHub review findings before merge