### PR TITLE
Generate market data before tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "predev": "npm run generate:market",
     "dev": "vite",
     "prebuild": "npm run generate:market",
+    "pretest": "npm run generate:market",
     "build": "tsc -b && vite build",
     "test": "node --test",
     "test:integration": "node --test ./test/*.test.mjs",


### PR DESCRIPTION
## Summary
- make npm test self-contained by generating market data first
- fix CI failures caused by tests depending on prior build artifacts

## Testing
- .\\scripts\\verify.ps1