### PR TITLE
ralph(#37): Improve unresolved and ambiguous item reporting so unmatched or low-confidence values are visible in the account report instead of silently disappearing from trust-critical totals.

### DIFF
--- a/gateway/report.mjs
+++ b/gateway/report.mjs
@@ -55,9 +55,16 @@ const derivedValueSource = (label, detail = null) => ({
   detail,
 });
 
-const unresolvedValueSource = () => ({
+const unresolvedValueSource = (detail = null) => ({
   type: "unresolved",
   label: "Unresolved Market Value",
+  detail,
+});
+
+const ambiguousValueSource = (detail = null) => ({
+  type: "ambiguous",
+  label: "Low-Confidence Market Value",
+  detail,
 });
 
 const isRotwEnvironment = (saveDir, files = []) => {
@@ -236,10 +243,26 @@ const stackQuantity = (item) => {
   return item.amount_in_shared_stash > 0 ? item.amount_in_shared_stash : 1;
 };
 
+const toWarningEntry = (item) => ({
+  kind: item.matchedBy === "ambiguous" ? "ambiguous" : "unresolved",
+  owner: item.owner,
+  name: item.name,
+  location: item.location,
+  source: item.source,
+  valueSource: item.valueSource,
+  includedInTotal: false,
+});
+
+const collectWarnings = (items, valuationWarnings, unmatchedItems) => {
+  const warnings = items.filter((item) => item.matchedBy === "unmatched" || item.matchedBy === "ambiguous").map(toWarningEntry);
+  valuationWarnings.push(...warnings);
+  unmatchedItems.push(...warnings.filter((warning) => warning.kind === "unresolved"));
+};
+
 const evaluateItem = (item, owner, location, source) => {
   const quantity = stackQuantity(item);
 
-  if (isLowConfidenceStoredAccessory(item, location) || (location !== "equipped" && isSuspiciousParsedItem(item))) {
+  if (isLowConfidenceStoredAccessory(item, location)) {
     return {
       id: `${owner}-${source}-${displayName(item)}`,
       name: displayName(item),
@@ -248,8 +271,22 @@ const evaluateItem = (item, owner, location, source) => {
       location,
       source,
       valueHr: 0,
-      matchedBy: "unmatched",
-      valueSource: unresolvedValueSource(),
+      matchedBy: "ambiguous",
+      valueSource: ambiguousValueSource("Stored accessory pricing needs affix-aware matching before it can affect HR totals."),
+    };
+  }
+
+  if (location !== "equipped" && isSuspiciousParsedItem(item)) {
+    return {
+      id: `${owner}-${source}-${displayName(item)}`,
+      name: displayName(item),
+      quantity,
+      owner,
+      location,
+      source,
+      valueHr: 0,
+      matchedBy: "ambiguous",
+      valueSource: ambiguousValueSource("Parsed item data looked suspicious, so it was excluded from trust-critical totals."),
     };
   }
 
@@ -329,7 +366,7 @@ const evaluateItem = (item, owner, location, source) => {
     source,
     valueHr: 0,
     matchedBy: "unmatched",
-    valueSource: unresolvedValueSource(),
+    valueSource: unresolvedValueSource("No workbook, token, or derived pricing match was found for this item."),
   };
 };
 
@@ -474,6 +511,7 @@ export const buildGatewayReport = async (saveDir) => {
 
   const valuedItems = [];
   const unmatchedItems = [];
+  const valuationWarnings = [];
   const runeCounts = new Map();
   const characterSummaries = [];
 
@@ -495,11 +533,7 @@ export const buildGatewayReport = async (saveDir) => {
     ];
 
     valuedItems.push(...characterValues);
-    unmatchedItems.push(
-      ...characterValues
-        .filter((item) => item.matchedBy === "unmatched")
-        .map((item) => ({ owner: item.owner, name: item.name, location: item.location, source: item.source, valueSource: item.valueSource })),
-    );
+    collectWarnings(characterValues, valuationWarnings, unmatchedItems);
 
     characterSummaries.push({
       name: character.header.name,
@@ -529,11 +563,7 @@ export const buildGatewayReport = async (saveDir) => {
       );
 
       valuedItems.push(...valuations);
-      unmatchedItems.push(
-        ...valuations
-          .filter((item) => item.matchedBy === "unmatched")
-          .map((item) => ({ owner: item.owner, name: item.name, location: item.location, source: item.source, valueSource: item.valueSource })),
-      );
+      collectWarnings(valuations, valuationWarnings, unmatchedItems);
     }
 
     if (materialItems.length) {
@@ -541,6 +571,7 @@ export const buildGatewayReport = async (saveDir) => {
         evaluateItem(item, stash.fileName, "shared-stash", `${stash.fileName} materials ${index + 1}`),
       );
       valuedItems.push(...materialValuations);
+      collectWarnings(materialValuations, valuationWarnings, unmatchedItems);
     }
   }
 
@@ -604,6 +635,12 @@ export const buildGatewayReport = async (saveDir) => {
       .slice(0, 12),
     allValuedItems: valuedItems.sort((left, right) => right.valueHr - left.valueHr),
     unmatchedItems,
+    valuationWarnings: {
+      totalCount: valuationWarnings.length,
+      unresolvedCount: valuationWarnings.filter((warning) => warning.kind === "unresolved").length,
+      ambiguousCount: valuationWarnings.filter((warning) => warning.kind === "ambiguous").length,
+      items: valuationWarnings,
+    },
     snapshot: {
       importedAt,
       totalHr,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -168,6 +168,7 @@ const derivePendingPairingId = () => {
 };
 
 const portraitForClass = (className: string) => classPortraits[className.toLowerCase()] ?? sorceressPortrait;
+const warningKindLabel = (kind: "unresolved" | "ambiguous") => (kind === "ambiguous" ? "Low confidence" : "Unmatched");
 const rulesetClass = (ruleset: "Classic" | "LoD" | "ROTW") => {
   if (ruleset === "ROTW") {
     return "ruleset-rotw";
@@ -230,6 +231,12 @@ const createPreviewReport = (): WealthReport => {
       },
     ],
     unmatchedItems: [],
+    valuationWarnings: {
+      totalCount: 0,
+      unresolvedCount: 0,
+      ambiguousCount: 0,
+      items: [],
+    },
     snapshot: {
       importedAt,
       totalHr: 4.13,
@@ -310,6 +317,48 @@ function TradeBreakdown(props: { valueHr: number }) {
         </span>
       ))}
     </div>
+  );
+}
+
+function ValuationWarningsPanel(props: { report: WealthReport | null }) {
+  const warnings = props.report?.valuationWarnings;
+  const visibleWarnings = warnings?.items.slice(0, 8) ?? [];
+
+  return (
+    <section className="panel warning-panel">
+      <div className="panel-header">
+        <h3>Valuation Warnings</h3>
+        <span>{warnings?.totalCount ?? 0} excluded items</span>
+      </div>
+      {!warnings?.totalCount ? (
+        <p className="empty-state">All parsed items matched a trusted valuation path.</p>
+      ) : (
+        <>
+          <p className="warning-summary">
+            {warnings.totalCount} items are excluded from HR totals: {warnings.unresolvedCount} unmatched and {warnings.ambiguousCount} low-confidence.
+          </p>
+          <div className="table">
+            {visibleWarnings.map((warning) => (
+              <div key={`${warning.owner}-${warning.source}-${warning.name}`} className="table-row">
+                <div>
+                  <strong>{warning.name}</strong>
+                  <span>
+                    {warning.owner} • {warning.source ?? warning.location}
+                  </span>
+                </div>
+                <div className="warning-meta">
+                  <span className={`warning-pill ${warning.kind}`}>{warningKindLabel(warning.kind)}</span>
+                  <span>{warning.valueSource.detail ?? warning.valueSource.label}</span>
+                </div>
+              </div>
+            ))}
+          </div>
+          {warnings.totalCount > visibleWarnings.length ? (
+            <p className="warning-summary">Showing {visibleWarnings.length} of {warnings.totalCount} excluded items.</p>
+          ) : null}
+        </>
+      )}
+    </section>
   );
 }
 
@@ -934,6 +983,8 @@ export default function App() {
               </section>
             </aside>
           </section>
+
+          <ValuationWarningsPanel report={report} />
 
           <section className="panel footnote-panel">
             <div className="panel-header">

--- a/src/lib/d2.ts
+++ b/src/lib/d2.ts
@@ -85,9 +85,16 @@ const derivedValueSource = (label: string, detail?: string): ValueSource => ({
   detail: detail ?? null,
 });
 
-const unresolvedValueSource = (): ValueSource => ({
+const unresolvedValueSource = (detail?: string): ValueSource => ({
   type: "unresolved",
   label: "Unresolved Market Value",
+  detail: detail ?? null,
+});
+
+const ambiguousValueSource = (detail?: string): ValueSource => ({
+  type: "ambiguous",
+  label: "Low-Confidence Market Value",
+  detail: detail ?? null,
 });
 
 const isRotwEnvironment = (names: string[]) => {
@@ -196,7 +203,66 @@ const matchTokenValue = (item: D2Item) => {
   return null;
 };
 
+const isLowConfidenceStoredAccessory = (item: D2Item, location: ItemLocation) => {
+  if (location === "equipped") {
+    return false;
+  }
+
+  return new Set(["amu", "rin", "jew", "cm1", "cm2", "cm3"]).has(item.type ?? "");
+};
+
+const isSuspiciousParsedItem = (item: D2Item) => {
+  const type = String(item.type ?? "");
+  return !/^[a-z0-9]{3}$/i.test(type);
+};
+
+const toWarningEntry = (item: ValuedItem) => ({
+  kind: (item.matchedBy === "ambiguous" ? "ambiguous" : "unresolved") as "ambiguous" | "unresolved",
+  owner: item.owner,
+  name: item.name,
+  location: item.location,
+  source: item.source,
+  valueSource: item.valueSource,
+  includedInTotal: false as const,
+});
+
+const collectWarnings = (
+  items: ValuedItem[],
+  valuationWarnings: WealthReport["valuationWarnings"]["items"],
+  unmatchedItems: WealthReport["unmatchedItems"],
+) => {
+  const warnings = items.filter((item) => item.matchedBy === "unmatched" || item.matchedBy === "ambiguous").map(toWarningEntry);
+  valuationWarnings.push(...warnings);
+  unmatchedItems.push(...warnings.filter((warning) => warning.kind === "unresolved"));
+};
+
 const evaluateItem = (item: D2Item, owner: string, location: ItemLocation, source: string): ValuedItem => {
+  if (isLowConfidenceStoredAccessory(item, location)) {
+    return {
+      id: `${owner}-${source}-${displayName(item)}`,
+      name: displayName(item),
+      owner,
+      location,
+      source,
+      valueHr: 0,
+      matchedBy: "ambiguous",
+      valueSource: ambiguousValueSource("Stored accessory pricing needs affix-aware matching before it can affect HR totals."),
+    };
+  }
+
+  if (location !== "equipped" && isSuspiciousParsedItem(item)) {
+    return {
+      id: `${owner}-${source}-${displayName(item)}`,
+      name: displayName(item),
+      owner,
+      location,
+      source,
+      valueHr: 0,
+      matchedBy: "ambiguous",
+      valueSource: ambiguousValueSource("Parsed item data looked suspicious, so it was excluded from trust-critical totals."),
+    };
+  }
+
   const resolvedRuneword = lookupRunewordName(item);
   if (resolvedRuneword && runewordRecipes[resolvedRuneword]) {
     const recipe = runewordRecipes[resolvedRuneword];
@@ -267,7 +333,7 @@ const evaluateItem = (item: D2Item, owner: string, location: ItemLocation, sourc
     source,
     valueHr: 0,
     matchedBy: "unmatched",
-    valueSource: unresolvedValueSource(),
+    valueSource: unresolvedValueSource("No workbook, token, or derived pricing match was found for this item."),
   };
 };
 
@@ -308,6 +374,7 @@ export const parseAccountFiles = async (files: FileList | File[]): Promise<Wealt
 
   const valuedItems: ValuedItem[] = [];
   const unmatchedItems: WealthReport["unmatchedItems"] = [];
+  const valuationWarnings: WealthReport["valuationWarnings"]["items"] = [];
   const runeCounts = new Map<string, { count: number; looseCount: number }>();
   const characterSummaries: WealthReport["characters"] = [];
 
@@ -331,11 +398,7 @@ export const parseAccountFiles = async (files: FileList | File[]): Promise<Wealt
     ];
 
     valuedItems.push(...characterValues);
-    unmatchedItems.push(
-      ...characterValues
-        .filter((item) => item.matchedBy === "unmatched")
-        .map((item) => ({ owner: item.owner, name: item.name, location: item.location, source: item.source, valueSource: item.valueSource })),
-    );
+    collectWarnings(characterValues, valuationWarnings, unmatchedItems);
 
     characterSummaries.push({
       name: character.header.name,
@@ -359,11 +422,7 @@ export const parseAccountFiles = async (files: FileList | File[]): Promise<Wealt
       );
 
       valuedItems.push(...valuations);
-      unmatchedItems.push(
-        ...valuations
-          .filter((item) => item.matchedBy === "unmatched")
-          .map((item) => ({ owner: item.owner, name: item.name, location: item.location, source: item.source, valueSource: item.valueSource })),
-      );
+      collectWarnings(valuations, valuationWarnings, unmatchedItems);
     }
   }
 
@@ -439,6 +498,12 @@ export const parseAccountFiles = async (files: FileList | File[]): Promise<Wealt
       .slice(0, 12),
     allValuedItems: valuedItems.sort((left, right) => right.valueHr - left.valueHr),
     unmatchedItems,
+    valuationWarnings: {
+      totalCount: valuationWarnings.length,
+      unresolvedCount: valuationWarnings.filter((warning) => warning.kind === "unresolved").length,
+      ambiguousCount: valuationWarnings.filter((warning) => warning.kind === "ambiguous").length,
+      items: valuationWarnings,
+    },
     snapshot: {
       importedAt,
       totalHr,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -7,7 +7,7 @@ export type MarketData = {
 };
 
 export type ValueSource = {
-  type: "rune-market" | "workbook" | "derived" | "unresolved";
+  type: "rune-market" | "workbook" | "derived" | "unresolved" | "ambiguous";
   label: string;
   sheet?: string;
   basis?: string | null;
@@ -33,8 +33,18 @@ export type ValuedItem = {
   sheet?: string;
   valueHr: number;
   tradeValue?: string | null;
-  matchedBy: "exact" | "token" | "socketed" | "unmatched";
+  matchedBy: "exact" | "token" | "socketed" | "unmatched" | "ambiguous";
   valueSource: ValueSource;
+};
+
+export type ValuationWarning = {
+  kind: "unresolved" | "ambiguous";
+  owner: string;
+  name: string;
+  location: ItemLocation;
+  source?: string;
+  valueSource: ValueSource;
+  includedInTotal: false;
 };
 
 export type RuneSummary = {
@@ -76,6 +86,12 @@ export type WealthReport = {
   topInventory: ValuedItem[];
   topSharedStash: ValuedItem[];
   allValuedItems: ValuedItem[];
-  unmatchedItems: Array<{ owner: string; name: string; location: ItemLocation; source?: string; valueSource: ValueSource }>;
+  unmatchedItems: ValuationWarning[];
+  valuationWarnings: {
+    totalCount: number;
+    unresolvedCount: number;
+    ambiguousCount: number;
+    items: ValuationWarning[];
+  };
   snapshot: WealthSnapshot;
 };

--- a/test/fixtures/parser-account.fixture.json
+++ b/test/fixtures/parser-account.fixture.json
@@ -189,6 +189,12 @@
       }
     ],
     "unmatchedItems": [],
+    "valuationWarnings": {
+      "totalCount": 0,
+      "unresolvedCount": 0,
+      "ambiguousCount": 0,
+      "items": []
+    },
     "snapshot": {
       "importedAt": "2026-03-29T16:00:00.000Z",
       "totalHr": 3.1875,


### PR DESCRIPTION
## Summary
- surface unresolved and ambiguous valuation warnings in gateway and browser reports
- add a dashboard panel for excluded low-confidence and unmatched items
- update the parser fixture report to include the new warning shape

## Tracking
- Closes #37
- Local verification: .\\scripts\\verify.ps1
- Merge rule: resolve GitHub review findings before merge