### PR TITLE
Harden loop CI gating and record merged task progress

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
 
       - name: Install dependencies

--- a/progress.txt
+++ b/progress.txt
@@ -111,3 +111,14 @@ VERIFY: .\\scripts\\verify.ps1
 FILES:
  - test/parser-fixtures.test.mjs
 
+[2026-03-29 14:30:05 -04:00] TASK: Improve unresolved and ambiguous item reporting so unmatched or low-confidence values are visible in the account report instead of silently disappearing from trust-critical totals.
+ISSUE: #37 https://github.com/bhavinamin/d2r-wealth/issues/37
+BRANCH: task/37-improve-unresolved-and-ambiguous-item-reporting
+VERIFY: .\\scripts\\verify.ps1
+FILES:
+ - gateway/report.mjs
+ - src/App.tsx
+ - src/lib/d2.ts
+ - src/lib/types.ts
+ - test/fixtures/parser-account.fixture.json
+

--- a/scripts/ralph-loop.ps1
+++ b/scripts/ralph-loop.ps1
@@ -4,6 +4,7 @@ param(
     [int]$MaxLoops = 25,
     [int]$MaxRecoveryAttempts = 2,
     [int]$RetryDelaySeconds = 10,
+    [int]$CiPollSeconds = 20,
     [string]$RemoteName = "origin",
     [string]$NotificationHandle = ""
 )
@@ -69,6 +70,34 @@ function Ensure-DefaultBranchReady([string]$RemoteName, [string]$DefaultBranch) 
 
     git fetch $RemoteName $DefaultBranch | Out-Null
     git pull --ff-only $RemoteName $DefaultBranch | Out-Null
+}
+
+function Get-DefaultBranchCiRuns([string]$DefaultBranch) {
+    $runsJson = gh run list --branch $DefaultBranch --json databaseId,status,conclusion,workflowName,url --limit 20
+    $runs = @()
+    if ($runsJson) {
+        $runs = $runsJson | ConvertFrom-Json
+    }
+    return @($runs | Where-Object { $_.workflowName -eq "CI" })
+}
+
+function Wait-ForDefaultBranchCi([string]$DefaultBranch, [int]$PollSeconds) {
+    while ($true) {
+        $runs = Get-DefaultBranchCiRuns -DefaultBranch $DefaultBranch
+        $activeRuns = @($runs | Where-Object { $_.status -ne "completed" })
+        if ($activeRuns.Count -eq 0) {
+            break
+        }
+
+        Write-Host "Waiting for $($activeRuns.Count) CI run(s) on '$DefaultBranch' to finish..."
+        Start-Sleep -Seconds $PollSeconds
+    }
+
+    $latestCompleted = @(Get-DefaultBranchCiRuns -DefaultBranch $DefaultBranch | Where-Object { $_.status -eq "completed" } | Select-Object -First 1)
+    if ($latestCompleted.Count -gt 0 -and $latestCompleted[0].conclusion -ne "success") {
+        $run = $latestCompleted[0]
+        throw "Default branch CI is red on '$DefaultBranch': $($run.url)"
+    }
 }
 
 function Invoke-LoggedPowerShellFile([string]$ScriptPath, [string[]]$Arguments, [string]$OutputFile) {
@@ -207,6 +236,8 @@ while ($loopCount -lt $MaxLoops) {
     $loopCount += 1
     Write-Host "Loop $loopCount of $MaxLoops"
 
+    Ensure-DefaultBranchReady -RemoteName $RemoteName -DefaultBranch $defaultBranch
+    Wait-ForDefaultBranchCi -DefaultBranch $defaultBranch -PollSeconds $CiPollSeconds
     Ensure-DefaultBranchReady -RemoteName $RemoteName -DefaultBranch $defaultBranch
 
     $success = $false


### PR DESCRIPTION
## Summary
- wait for default-branch CI to finish before starting the next loop iteration
- stop the supervisor when default-branch CI is red
- record the already-merged #37 task in progress to avoid duplicate selection

## Testing
- .\\scripts\\verify.ps1
- PowerShell parse check for scripts/ralph-loop.ps1