### PR TITLE
Run parser tests on Windows and builds on Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
+  test-windows:
+    runs-on: windows-latest
 
     steps:
       - name: Checkout
@@ -27,6 +27,22 @@ jobs:
 
       - name: Run automated tests
         run: npm test
+
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
 
       - name: Build
         run: npm run build


### PR DESCRIPTION
## Summary
- run parser-heavy npm test on windows-latest where the gateway parser is actually supported
- keep npm run build on ubuntu-latest for the web/build path

## Testing
- .\\scripts\\verify.ps1