### PR TITLE
ralph(#61): Ship a Windows native client app that uses Discord auth and manages sync lifecycle.

### DIFF
--- a/native-gateway/D2Wealth.Gateway.Win/ConsoleGatewayHost.cs
+++ b/native-gateway/D2Wealth.Gateway.Win/ConsoleGatewayHost.cs
@@ -182,20 +182,28 @@ internal sealed class ConsoleGatewayHost
             return $"Gateway API not reachable at http://{settings.Host}:{settings.Port}.";
         }
 
-        var validation = health.SaveValidation is null
-            ? "validation unknown"
-            : health.SaveValidation.Valid
-                ? $"validation ok ({health.SaveValidation.CharacterCount} characters)"
-                : $"validation failed ({health.SaveValidation.Message})";
-        var sync = !string.IsNullOrWhiteSpace(health.LastBackendSyncError)
-            ? $"sync error: {health.LastBackendSyncError}"
-            : !string.IsNullOrWhiteSpace(health.LastBackendSyncAt)
-                ? $"last sync: {health.LastBackendSyncAt}"
-                : string.IsNullOrWhiteSpace(health.SyncToken)
-                    ? "not linked"
-                    : "linked, waiting for first sync";
+        var lifecycle = GatewayStatusPresentation.LifecycleLabel(health);
+        var saveLabel = health.StatusSummary?.Save?.Label ?? (health.SaveValidation?.Valid == true ? "Ready" : "Needs Attention");
+        var saveDetail = health.StatusSummary?.Save?.Detail ?? health.SaveValidation?.Message ?? "Waiting for save scan.";
+        var pairingLabel = health.StatusSummary?.Pairing?.Label ?? (string.IsNullOrWhiteSpace(health.SyncToken) ? "Ready To Pair" : "Paired");
+        var pairingDetail = health.StatusSummary?.Pairing?.Detail ?? GatewayStatusPresentation.PairingMessage(health, hasUnsavedChanges: false);
+        var syncLabel = health.StatusSummary?.Sync?.Label ?? lifecycle;
+        var syncDetail = health.StatusSummary?.Sync?.Detail ?? GatewayStatusPresentation.LifecycleDetail(health);
+        var lastErrorLabel = GatewayStatusPresentation.ErrorHeadline(health);
+        var lastErrorDetail = GatewayStatusPresentation.ErrorDetail(health);
+        var lastUpdate = health.LastSuccessfulAccountUpdateAt ?? "Never";
 
-        return $"Gateway ok={health.Ok}; saveDir='{health.SaveDir}'; {validation}; {sync}.";
+        return string.Join(
+            Environment.NewLine,
+            [
+                $"Lifecycle: {lifecycle}",
+                $"Save Folder: {health.SaveDir}",
+                $"Save Validation: {saveLabel} - {saveDetail}",
+                $"Pairing: {pairingLabel} - {pairingDetail}",
+                $"Sync: {syncLabel} - {syncDetail}",
+                $"Last Error: {lastErrorLabel} - {lastErrorDetail}",
+                $"Last Account Update: {lastUpdate}",
+            ]);
     }
 
     private void PrintHelp()

--- a/native-gateway/D2Wealth.Gateway.Win/GatewayApiClient.cs
+++ b/native-gateway/D2Wealth.Gateway.Win/GatewayApiClient.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Net.Http.Json;
+using System.Net;
 using System.Text;
 using System.Text.Json;
 
@@ -47,6 +48,7 @@ internal sealed class GatewayApiClient
 
     public async Task PairGatewayAsync(GatewaySettings settings, Action<string> statusCallback, CancellationToken cancellationToken = default)
     {
+        statusCallback("Opening Discord sign-in in your browser...");
         var pairingResponse = await _httpClient.PostAsJsonAsync($"{settings.BackendUrl.TrimEnd('/')}/api/gateway/pairing-sessions", new
         {
             clientId = settings.ClientId,
@@ -86,6 +88,7 @@ internal sealed class GatewayApiClient
 
             settings.SyncToken = claim.GatewayToken;
             _settingsStore.Save(settings);
+            statusCallback("Pairing approved. Waiting for the first sync result...");
             return;
         }
 
@@ -108,9 +111,21 @@ internal sealed class GatewayApiClient
         request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", settings.SyncToken);
 
         using var response = await _httpClient.SendAsync(request, cancellationToken);
-        response.EnsureSuccessStatusCode();
+        if (!response.IsSuccessStatusCode)
+        {
+            if (response.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden)
+            {
+                settings.SyncToken = string.Empty;
+                settings.AccountId = string.Empty;
+                _settingsStore.Save(settings);
+                return;
+            }
+
+            response.EnsureSuccessStatusCode();
+        }
 
         settings.SyncToken = string.Empty;
+        settings.AccountId = string.Empty;
         _settingsStore.Save(settings);
     }
 

--- a/native-gateway/D2Wealth.Gateway.Win/GatewayHealth.cs
+++ b/native-gateway/D2Wealth.Gateway.Win/GatewayHealth.cs
@@ -19,14 +19,23 @@ internal sealed class GatewayHealth
     [JsonPropertyName("syncToken")]
     public string SyncToken { get; set; } = string.Empty;
 
+    [JsonPropertyName("files")]
+    public List<GatewayTrackedFile> Files { get; set; } = [];
+
     [JsonPropertyName("lastBackendSyncAt")]
     public string? LastBackendSyncAt { get; set; }
 
     [JsonPropertyName("lastBackendSyncError")]
     public string? LastBackendSyncError { get; set; }
 
+    [JsonPropertyName("lastSuccessfulAccountUpdateAt")]
+    public string? LastSuccessfulAccountUpdateAt { get; set; }
+
     [JsonPropertyName("saveValidation")]
     public SaveValidationStatus? SaveValidation { get; set; }
+
+    [JsonPropertyName("statusSummary")]
+    public GatewayStatusSummary? StatusSummary { get; set; }
 }
 
 internal sealed class SaveValidationStatus
@@ -42,6 +51,51 @@ internal sealed class SaveValidationStatus
 
     [JsonPropertyName("checkedAt")]
     public string? CheckedAt { get; set; }
+
+    [JsonPropertyName("nextRetryAt")]
+    public string? NextRetryAt { get; set; }
+}
+
+internal sealed class GatewayStatusSummary
+{
+    [JsonPropertyName("save")]
+    public GatewayStatusEntry? Save { get; set; }
+
+    [JsonPropertyName("pairing")]
+    public GatewayStatusEntry? Pairing { get; set; }
+
+    [JsonPropertyName("sync")]
+    public GatewayStatusEntry? Sync { get; set; }
+
+    [JsonPropertyName("lastError")]
+    public GatewayStatusError? LastError { get; set; }
+
+    [JsonPropertyName("dashboardFreshness")]
+    public GatewayStatusEntry? DashboardFreshness { get; set; }
+}
+
+internal sealed class GatewayStatusEntry
+{
+    [JsonPropertyName("state")]
+    public string State { get; set; } = string.Empty;
+
+    [JsonPropertyName("label")]
+    public string Label { get; set; } = string.Empty;
+
+    [JsonPropertyName("detail")]
+    public string Detail { get; set; } = string.Empty;
+}
+
+internal sealed class GatewayStatusError
+{
+    [JsonPropertyName("scope")]
+    public string Scope { get; set; } = string.Empty;
+
+    [JsonPropertyName("message")]
+    public string Message { get; set; } = string.Empty;
+
+    [JsonPropertyName("occurredAt")]
+    public string? OccurredAt { get; set; }
 }
 
 internal sealed class PairingSessionResponse
@@ -63,4 +117,19 @@ internal sealed class PairingClaimResponse
 
     [JsonPropertyName("gatewayToken")]
     public string GatewayToken { get; set; } = string.Empty;
+}
+
+internal sealed class GatewayTrackedFile
+{
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = string.Empty;
+
+    [JsonPropertyName("size")]
+    public long Size { get; set; }
+
+    [JsonPropertyName("modifiedAt")]
+    public string? ModifiedAt { get; set; }
+
+    [JsonPropertyName("type")]
+    public string Type { get; set; } = string.Empty;
 }

--- a/native-gateway/D2Wealth.Gateway.Win/GatewayStatusPresentation.cs
+++ b/native-gateway/D2Wealth.Gateway.Win/GatewayStatusPresentation.cs
@@ -1,0 +1,88 @@
+namespace D2Wealth.Gateway.Win;
+
+internal static class GatewayStatusPresentation
+{
+    public static string LifecycleLabel(GatewayHealth? health)
+    {
+        var syncState = health?.StatusSummary?.Sync?.State;
+        return syncState switch
+        {
+            "synced" => "Connected",
+            "pending" => "Connected",
+            "syncing" => "Syncing",
+            "error" => "Error",
+            "blocked" => "Blocked",
+            "not-paired" => "Disconnected",
+            _ when !string.IsNullOrWhiteSpace(health?.SyncToken) => "Connected",
+            _ => "Disconnected",
+        };
+    }
+
+    public static string LifecycleDetail(GatewayHealth? health)
+    {
+        if (health?.StatusSummary?.Sync?.Detail is { Length: > 0 } detail)
+        {
+            return detail;
+        }
+
+        if (!string.IsNullOrWhiteSpace(health?.LastBackendSyncError))
+        {
+            return health.LastBackendSyncError;
+        }
+
+        if (!string.IsNullOrWhiteSpace(health?.LastBackendSyncAt))
+        {
+            return $"Last upload reached the backend at {health.LastBackendSyncAt}.";
+        }
+
+        return string.IsNullOrWhiteSpace(health?.SyncToken)
+            ? "This PC is not linked yet. Sign in with Discord to connect it."
+            : "Pairing is complete and the gateway is waiting for its first successful upload.";
+    }
+
+    public static string PairingMessage(GatewayHealth? health, bool hasUnsavedChanges)
+    {
+        var saveState = health?.StatusSummary?.Save?.State ?? string.Empty;
+        var pairingState = health?.StatusSummary?.Pairing?.State ?? string.Empty;
+        var syncState = health?.StatusSummary?.Sync?.State ?? string.Empty;
+
+        if (pairingState == "paired" && syncState == "synced")
+        {
+            return "This PC is linked to your D2 Wealth account and can keep syncing in the background.";
+        }
+
+        if (pairingState == "paired")
+        {
+            return "This PC is linked, but sync still needs to finish cleanly before the dashboard is current.";
+        }
+
+        if (hasUnsavedChanges)
+        {
+            return "Save the Diablo II folder choice first. After that, Discord sign-in can open in your browser.";
+        }
+
+        if (saveState != "ready")
+        {
+            return "Choose a valid Diablo II save folder before starting Discord sign-in for this PC.";
+        }
+
+        return "Sign in with Discord in the browser and approve pairing for this PC. The gateway will claim its sync token automatically.";
+    }
+
+    public static string ErrorHeadline(GatewayHealth? health)
+    {
+        var lastError = health?.StatusSummary?.LastError;
+        if (lastError is null)
+        {
+            return "Clear";
+        }
+
+        return string.IsNullOrWhiteSpace(lastError.Scope) ? "Error" : lastError.Scope;
+    }
+
+    public static string ErrorDetail(GatewayHealth? health)
+    {
+        var lastError = health?.StatusSummary?.LastError;
+        return lastError?.Message ?? "No recent blocking error.";
+    }
+}

--- a/native-gateway/D2Wealth.Gateway.Win/SettingsForm.cs
+++ b/native-gateway/D2Wealth.Gateway.Win/SettingsForm.cs
@@ -5,13 +5,26 @@ namespace D2Wealth.Gateway.Win;
 internal sealed class SettingsForm : Form
 {
     private readonly TextBox _saveDirTextBox;
+    private readonly Label _lifecycleLabel;
     private readonly Label _saveStatusLabel;
+    private readonly Label _pairCopyLabel;
     private readonly Label _syncStatusLabel;
+    private readonly Label _pairingStatusLabel;
+    private readonly Label _lastErrorStatusLabel;
+    private readonly Label _lastUpdateStatusLabel;
     private readonly CheckBox _autoStartCheckbox;
     private readonly Button _saveButton;
     private readonly Button _pairButton;
     private readonly Button _disconnectButton;
     private readonly Button _browseButton;
+
+    private GatewaySettings _appliedSettings = new();
+    private GatewayHealth? _lastHealth;
+    private bool _saveDirDirty;
+    private bool _autoStartDirty;
+    private bool _applyingSettings;
+    private bool _busy;
+    private string? _busyMessage;
 
     public event Func<Task>? SaveRequested;
     public event Func<Task>? PairRequested;
@@ -24,43 +37,97 @@ internal sealed class SettingsForm : Form
         FormBorderStyle = FormBorderStyle.FixedDialog;
         MaximizeBox = false;
         MinimizeBox = false;
-        ClientSize = new Size(480, 320);
+        ClientSize = new Size(560, 470);
         BackColor = Color.FromArgb(20, 17, 15);
         ForeColor = Color.FromArgb(243, 237, 225);
 
-        var saveTitle = new Label { Text = "Save Folder", Left = 18, Top = 18, Width = 120 };
-        _saveDirTextBox = new TextBox { Left = 18, Top = 42, Width = 340 };
-        _browseButton = new Button { Text = "Browse", Left = 368, Top = 40, Width = 90 };
-        _saveStatusLabel = new Label { Left = 18, Top = 74, Width = 440, Height = 40 };
+        var titleLabel = new Label
+        {
+            Text = "D2 Wealth Gateway",
+            Left = 18,
+            Top = 16,
+            Width = 250,
+            Font = new Font("Segoe UI", 12, FontStyle.Bold),
+        };
+        _lifecycleLabel = new Label
+        {
+            Left = 400,
+            Top = 16,
+            Width = 142,
+            Height = 30,
+            TextAlign = ContentAlignment.MiddleCenter,
+            BackColor = Color.FromArgb(49, 45, 41),
+            ForeColor = Color.FromArgb(243, 237, 225),
+            Font = new Font("Segoe UI", 9, FontStyle.Bold),
+        };
 
-        var accountTitle = new Label { Text = "Account", Left = 18, Top = 122, Width = 120 };
-        _pairButton = new Button { Text = "Sign in with Discord", Left = 18, Top = 146, Width = 180, Height = 34 };
-        _disconnectButton = new Button { Text = "Disconnect", Left = 210, Top = 146, Width = 120, Height = 34 };
-        _syncStatusLabel = new Label { Left = 18, Top = 188, Width = 440, Height = 46 };
+        var saveTitle = new Label { Text = "Save Folder", Left = 18, Top = 62, Width = 120 };
+        _saveDirTextBox = new TextBox { Left = 18, Top = 86, Width = 430 };
+        _browseButton = new Button { Text = "Browse", Left = 458, Top = 84, Width = 84, Height = 28 };
+        _saveStatusLabel = new Label { Left = 18, Top = 118, Width = 524, Height = 42 };
+
+        var accountTitle = new Label { Text = "Account Link", Left = 18, Top = 168, Width = 120 };
+        _pairCopyLabel = new Label { Left = 18, Top = 192, Width = 524, Height = 42 };
+        _pairButton = new Button { Text = "Sign in with Discord", Left = 18, Top = 238, Width = 182, Height = 34 };
+        _disconnectButton = new Button { Text = "Disconnect", Left = 212, Top = 238, Width = 120, Height = 34 };
+
+        var statusTitle = new Label { Text = "Sync Lifecycle", Left = 18, Top = 286, Width = 140 };
+        _syncStatusLabel = new Label { Left = 18, Top = 310, Width = 250, Height = 62 };
+        _pairingStatusLabel = new Label { Left = 292, Top = 310, Width = 250, Height = 62 };
+        _lastErrorStatusLabel = new Label { Left = 18, Top = 378, Width = 250, Height = 52 };
+        _lastUpdateStatusLabel = new Label { Left = 292, Top = 378, Width = 250, Height = 52 };
 
         _autoStartCheckbox = new CheckBox
         {
             Text = "Start automatically with Windows",
             Left = 18,
-            Top = 244,
+            Top = 432,
             Width = 240,
         };
-        _saveButton = new Button { Text = "Save Settings", Left = 318, Top = 238, Width = 140, Height = 34 };
+        _saveButton = new Button { Text = "Save Settings", Left = 402, Top = 426, Width = 140, Height = 34 };
 
+        _saveDirTextBox.TextChanged += (_, _) =>
+        {
+            if (_applyingSettings)
+            {
+                return;
+            }
+
+            _saveDirDirty = true;
+            RefreshView();
+        };
+        _autoStartCheckbox.CheckedChanged += (_, _) =>
+        {
+            if (_applyingSettings)
+            {
+                return;
+            }
+
+            _autoStartDirty = true;
+            RefreshView();
+        };
         _browseButton.Click += BrowseButtonOnClick;
         _saveButton.Click += async (_, _) => { if (SaveRequested is not null) await SaveRequested(); };
         _pairButton.Click += async (_, _) => { if (PairRequested is not null) await PairRequested(); };
         _disconnectButton.Click += async (_, _) => { if (DisconnectRequested is not null) await DisconnectRequested(); };
 
-        Controls.AddRange([
+        Controls.AddRange(
+        [
+            titleLabel,
+            _lifecycleLabel,
             saveTitle,
             _saveDirTextBox,
             _browseButton,
             _saveStatusLabel,
             accountTitle,
+            _pairCopyLabel,
             _pairButton,
             _disconnectButton,
+            statusTitle,
             _syncStatusLabel,
+            _pairingStatusLabel,
+            _lastErrorStatusLabel,
+            _lastUpdateStatusLabel,
             _autoStartCheckbox,
             _saveButton,
         ]);
@@ -81,38 +148,118 @@ internal sealed class SettingsForm : Form
 
     public void ApplySettings(GatewaySettings settings, GatewayHealth? health)
     {
-        _saveDirTextBox.Text = settings.SaveDir;
-        _autoStartCheckbox.Checked = settings.AutoStart;
+        _appliedSettings = CloneSettings(settings);
+        _lastHealth = health;
 
-        var linked = !string.IsNullOrWhiteSpace(settings.SyncToken);
-        _pairButton.Visible = !linked;
-        _disconnectButton.Visible = linked;
+        if (_saveDirDirty && string.Equals(_saveDirTextBox.Text.Trim(), settings.SaveDir, StringComparison.Ordinal))
+        {
+            _saveDirDirty = false;
+        }
 
-        var validation = health?.SaveValidation;
-        _saveStatusLabel.Text = validation?.Message ?? "Choose the folder that contains your active Diablo II save files.";
-        _saveStatusLabel.ForeColor = validation?.Valid == true ? Color.FromArgb(137, 223, 157) : Color.FromArgb(243, 237, 225);
+        if (_autoStartDirty && _autoStartCheckbox.Checked == settings.AutoStart)
+        {
+            _autoStartDirty = false;
+        }
 
-        _syncStatusLabel.Text = linked
-            ? health?.LastBackendSyncAt is not null
-                ? $"Connected. Last sync: {health.LastBackendSyncAt}"
-                : health?.LastBackendSyncError is not null
-                    ? $"Linked, but sync failed: {health.LastBackendSyncError}"
-                    : "Linked. Waiting for first backend sync."
-            : "Not linked. Sign in with Discord to pair this PC.";
+        _applyingSettings = true;
+        try
+        {
+            if (!_saveDirDirty && !_saveDirTextBox.Focused)
+            {
+                _saveDirTextBox.Text = settings.SaveDir;
+            }
+
+            if (!_autoStartDirty && !_autoStartCheckbox.Focused)
+            {
+                _autoStartCheckbox.Checked = settings.AutoStart;
+            }
+        }
+        finally
+        {
+            _applyingSettings = false;
+        }
+
+        RefreshView();
     }
 
     public void SetBusyState(bool busy, string? statusMessage = null)
     {
+        _busy = busy;
+        _busyMessage = busy ? statusMessage : null;
         UseWaitCursor = busy;
-        _saveButton.Enabled = !busy;
-        _pairButton.Enabled = !busy;
-        _disconnectButton.Enabled = !busy;
-        _browseButton.Enabled = !busy;
-        if (!string.IsNullOrWhiteSpace(statusMessage))
-        {
-            _syncStatusLabel.Text = statusMessage;
-        }
+        RefreshView();
     }
+
+    private void RefreshView()
+    {
+        var linked = !string.IsNullOrWhiteSpace(_appliedSettings.SyncToken);
+        var hasUnsavedChanges = _saveDirDirty || _autoStartDirty;
+        var lifecycle = _busy ? "Working" : GatewayStatusPresentation.LifecycleLabel(_lastHealth);
+        var validation = _lastHealth?.SaveValidation;
+        var syncLabel = _lastHealth?.StatusSummary?.Sync?.Label ?? GatewayStatusPresentation.LifecycleLabel(_lastHealth);
+        var syncDetail = _busyMessage ?? GatewayStatusPresentation.LifecycleDetail(_lastHealth);
+        var pairingLabel = _lastHealth?.StatusSummary?.Pairing?.Label ?? (linked ? "Paired" : "Ready To Pair");
+        var pairingDetail = _lastHealth?.StatusSummary?.Pairing?.Detail ?? GatewayStatusPresentation.PairingMessage(_lastHealth, hasUnsavedChanges);
+        var lastUpdate = _lastHealth?.LastSuccessfulAccountUpdateAt ?? "Never";
+        var lastUpdateDetail = _lastHealth?.StatusSummary?.DashboardFreshness?.Detail
+            ?? "The backend does not have a successful upload from this gateway yet.";
+        _lifecycleLabel.Text = lifecycle;
+        _lifecycleLabel.BackColor = LifecycleBackColor(lifecycle);
+        _lifecycleLabel.ForeColor = LifecycleForeColor(lifecycle);
+
+        _saveStatusLabel.Text = validation?.Message ?? "Choose the folder that contains your active Diablo II save files.";
+        _saveStatusLabel.ForeColor = validation?.Valid == true ? Color.FromArgb(137, 223, 157) : Color.FromArgb(243, 237, 225);
+
+        _pairCopyLabel.Text = _busyMessage ?? GatewayStatusPresentation.PairingMessage(_lastHealth, hasUnsavedChanges);
+        _pairCopyLabel.ForeColor = _busy ? Color.FromArgb(244, 216, 167) : Color.FromArgb(225, 215, 199);
+
+        _pairButton.Visible = !linked;
+        _disconnectButton.Visible = linked;
+        _pairButton.Enabled = !_busy && !hasUnsavedChanges && validation?.Valid == true;
+        _disconnectButton.Enabled = !_busy;
+        _saveButton.Enabled = !_busy && hasUnsavedChanges;
+        _browseButton.Enabled = !_busy;
+        _saveDirTextBox.Enabled = !_busy;
+        _autoStartCheckbox.Enabled = !_busy;
+
+        _syncStatusLabel.Text = $"Sync State: {syncLabel}{Environment.NewLine}{syncDetail}";
+        _pairingStatusLabel.Text = $"Pairing: {pairingLabel}{Environment.NewLine}{pairingDetail}";
+        _lastErrorStatusLabel.Text = $"Last Error: {GatewayStatusPresentation.ErrorHeadline(_lastHealth)}{Environment.NewLine}{GatewayStatusPresentation.ErrorDetail(_lastHealth)}";
+        _lastUpdateStatusLabel.Text = $"Last Account Update: {lastUpdate}{Environment.NewLine}{lastUpdateDetail}";
+    }
+
+    private static GatewaySettings CloneSettings(GatewaySettings settings) => new()
+    {
+        Host = settings.Host,
+        Port = settings.Port,
+        SaveDir = settings.SaveDir,
+        AutoStart = settings.AutoStart,
+        DashboardUrl = settings.DashboardUrl,
+        BackendUrl = settings.BackendUrl,
+        AccountId = settings.AccountId,
+        ClientId = settings.ClientId,
+        SyncToken = settings.SyncToken,
+    };
+
+    private static Color LifecycleBackColor(string lifecycle) => lifecycle switch
+    {
+        "Connected" => Color.FromArgb(57, 98, 66),
+        "Syncing" => Color.FromArgb(92, 68, 31),
+        "Error" => Color.FromArgb(98, 43, 39),
+        "Blocked" => Color.FromArgb(92, 68, 31),
+        "Working" => Color.FromArgb(92, 68, 31),
+        _ => Color.FromArgb(49, 45, 41),
+    };
+
+    private static Color LifecycleForeColor(string lifecycle) => lifecycle switch
+    {
+        "Connected" => Color.FromArgb(137, 223, 157),
+        "Syncing" => Color.FromArgb(244, 216, 167),
+        "Error" => Color.FromArgb(255, 176, 167),
+        "Blocked" => Color.FromArgb(244, 216, 167),
+        "Working" => Color.FromArgb(244, 216, 167),
+        _ => Color.FromArgb(243, 237, 225),
+    };
 
     private void BrowseButtonOnClick(object? sender, EventArgs e)
     {
@@ -126,6 +273,8 @@ internal sealed class SettingsForm : Form
         if (dialog.ShowDialog(this) == DialogResult.OK)
         {
             _saveDirTextBox.Text = dialog.SelectedPath;
+            _saveDirDirty = true;
+            RefreshView();
         }
     }
 }

--- a/native-gateway/D2Wealth.Gateway.Win/TrayApplicationContext.cs
+++ b/native-gateway/D2Wealth.Gateway.Win/TrayApplicationContext.cs
@@ -92,10 +92,7 @@ internal sealed class TrayApplicationContext : ApplicationContext
         try
         {
             _logger.Info("Saving gateway settings from tray UI.");
-            _settings = _settingsForm.CollectSettings(_settings);
-            _settingsStore.Save(_settings);
-            _processManager.ApplyAutoStart(_settings.AutoStart);
-            var health = await _apiClient.SaveGatewaySettingsAsync(_settings);
+            var health = await PersistFormSettingsAsync();
             _settingsForm.ApplySettings(_settings, health);
         }
         finally
@@ -109,6 +106,14 @@ internal sealed class TrayApplicationContext : ApplicationContext
         _settingsForm.SetBusyState(true, "Opening browser for Discord sign-in...");
         try
         {
+            _logger.Info("Persisting tray settings before Discord pairing.");
+            var savedHealth = await PersistFormSettingsAsync();
+            _settingsForm.ApplySettings(_settings, savedHealth);
+            if (savedHealth?.SaveValidation?.Valid != true)
+            {
+                return;
+            }
+
             _logger.Info("Starting Discord pairing from tray UI.");
             await _apiClient.PairGatewayAsync(_settings, status => _settingsForm.SetBusyState(true, status));
             _settingsStore.Save(_settings);
@@ -145,11 +150,17 @@ internal sealed class TrayApplicationContext : ApplicationContext
     {
         var health = await _apiClient.LoadHealthAsync(_settings);
         _settingsForm.ApplySettings(_settings, health);
-        _notifyIcon.Text = health?.LastBackendSyncError is not null
-            ? "D2 Wealth Gateway - Sync Error"
-            : !string.IsNullOrWhiteSpace(_settings.SyncToken)
-                ? "D2 Wealth Gateway - Linked"
-                : "D2 Wealth Gateway";
+        var lifecycle = GatewayStatusPresentation.LifecycleLabel(health);
+        _notifyIcon.Text = $"D2 Wealth Gateway - {lifecycle}";
+    }
+
+    private async Task<GatewayHealth?> PersistFormSettingsAsync()
+    {
+        _settings = _settingsForm.CollectSettings(_settings);
+        _settingsStore.Save(_settings);
+        _processManager.ApplyAutoStart(_settings.AutoStart);
+        _processManager.Start();
+        return await _apiClient.SaveGatewaySettingsAsync(_settings);
     }
 
     private async Task ExitAsync()

--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
     "backend": "node ./backend/server.mjs",
     "gateway": "node ./gateway/server.mjs",
     "gateway:tray": "electron ./gateway/tray.mjs",
-    "dist:gateway": "npm run generate:market && electron-builder --win msi"
+    "dist:gateway": "npm run generate:market && electron-builder --win msi",
+    "native:build": "dotnet build ./native-gateway/D2Wealth.Gateway.Win/D2Wealth.Gateway.Win.csproj -c Release",
+    "native:publish": "powershell -ExecutionPolicy Bypass -File ./scripts/publish-native-gateway.ps1"
   },
   "dependencies": {
     "@d2runewizard/d2s": "^2.0.130",

--- a/progress.txt
+++ b/progress.txt
@@ -164,3 +164,18 @@ FILES:
  - test/fixtures/parser-account.fixture.json
  - test/parser-fixtures.test.mjs
 
+[2026-03-29 18:32:53 -04:00] TASK: Ship a Windows native client app that uses Discord auth and manages sync lifecycle.
+ISSUE: #61 https://github.com/bhavinamin/d2r-wealth/issues/61
+BRANCH: task/61-ship-a-windows-native-client-app-that-uses-disco
+VERIFY: .\\scripts\\verify.ps1
+FILES:
+ - native-gateway/D2Wealth.Gateway.Win/ConsoleGatewayHost.cs
+ - native-gateway/D2Wealth.Gateway.Win/GatewayApiClient.cs
+ - native-gateway/D2Wealth.Gateway.Win/GatewayHealth.cs
+ - native-gateway/D2Wealth.Gateway.Win/GatewayStatusPresentation.cs
+ - native-gateway/D2Wealth.Gateway.Win/SettingsForm.cs
+ - native-gateway/D2Wealth.Gateway.Win/TrayApplicationContext.cs
+ - package.json
+ - scripts/publish-native-gateway.ps1
+ - scripts/verify.ps1
+

--- a/scripts/publish-native-gateway.ps1
+++ b/scripts/publish-native-gateway.ps1
@@ -1,0 +1,94 @@
+[CmdletBinding()]
+param(
+    [string]$Runtime = "win-x64",
+    [string]$Configuration = "Release",
+    [string]$OutputRoot = "",
+    [switch]$SkipArchive
+)
+
+$ErrorActionPreference = "Stop"
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+$projectPath = Join-Path $repoRoot "native-gateway\D2Wealth.Gateway.Win\D2Wealth.Gateway.Win.csproj"
+$packageJsonPath = Join-Path $repoRoot "package.json"
+$packageJson = Get-Content -LiteralPath $packageJsonPath -Raw | ConvertFrom-Json
+$version = [string]$packageJson.version
+
+$resolvedOutputRoot = if ([string]::IsNullOrWhiteSpace($OutputRoot)) {
+    Join-Path $repoRoot "release\native-gateway"
+}
+else {
+    $OutputRoot
+}
+
+$outputRootResolved = [System.IO.Path]::GetFullPath($resolvedOutputRoot)
+$bundleRoot = Join-Path $outputRootResolved "D2-Wealth-Gateway-Native"
+$archivePath = Join-Path $outputRootResolved ("D2-Wealth-Gateway-Native-{0}-{1}.zip" -f $version, $Runtime)
+
+if (Test-Path -LiteralPath $bundleRoot) {
+    Remove-Item -LiteralPath $bundleRoot -Recurse -Force
+}
+
+New-Item -ItemType Directory -Path $bundleRoot | Out-Null
+
+Write-Host "Publishing native gateway wrapper..."
+dotnet publish $projectPath `
+    -c $Configuration `
+    -r $Runtime `
+    --self-contained true `
+    -p:PublishSingleFile=true `
+    -p:IncludeNativeLibrariesForSelfExtract=true `
+    -o $bundleRoot
+
+if ($LASTEXITCODE -ne 0) {
+    throw "dotnet publish failed with exit code $LASTEXITCODE."
+}
+
+$nodeCommand = Get-Command node -ErrorAction Stop
+$nodeTargetDir = Join-Path $bundleRoot "node"
+New-Item -ItemType Directory -Path $nodeTargetDir | Out-Null
+Copy-Item -LiteralPath $nodeCommand.Source -Destination (Join-Path $nodeTargetDir "node.exe") -Force
+
+Write-Host "Copying gateway runtime files..."
+Copy-Item -LiteralPath (Join-Path $repoRoot "gateway") -Destination (Join-Path $bundleRoot "gateway") -Recurse -Force
+
+$generatedDir = Join-Path $bundleRoot "src\generated"
+New-Item -ItemType Directory -Path $generatedDir -Force | Out-Null
+Copy-Item -LiteralPath (Join-Path $repoRoot "src\generated\market-data.json") -Destination (Join-Path $generatedDir "market-data.json") -Force
+Copy-Item -LiteralPath $packageJsonPath -Destination (Join-Path $bundleRoot "package.json") -Force
+
+$moduleTargetDir = Join-Path $bundleRoot "node_modules\@d2runewizard"
+New-Item -ItemType Directory -Path $moduleTargetDir -Force | Out-Null
+Copy-Item -LiteralPath (Join-Path $repoRoot "node_modules\@d2runewizard\d2s") -Destination (Join-Path $moduleTargetDir "d2s") -Recurse -Force
+
+$manifest = @{
+    productName = "D2 Wealth Gateway Native"
+    version = $version
+    runtime = $Runtime
+    publishedAt = (Get-Date).ToString("o")
+    files = @(
+        "D2Wealth.Gateway.Win.exe",
+        "node\node.exe",
+        "gateway\server.mjs",
+        "gateway\service.mjs",
+        "gateway\report.mjs",
+        "src\generated\market-data.json",
+        "node_modules\@d2runewizard\d2s"
+    )
+}
+$manifest | ConvertTo-Json -Depth 4 | Set-Content -LiteralPath (Join-Path $bundleRoot "bundle-manifest.json")
+
+if (-not $SkipArchive) {
+    if (Test-Path -LiteralPath $archivePath) {
+        Remove-Item -LiteralPath $archivePath -Force
+    }
+
+    Write-Host "Creating native gateway archive..."
+    Compress-Archive -Path (Join-Path $bundleRoot "*") -DestinationPath $archivePath
+}
+
+Write-Host "Native gateway bundle ready:"
+Write-Host "  Bundle:  $bundleRoot"
+if (-not $SkipArchive) {
+    Write-Host "  Archive: $archivePath"
+}

--- a/scripts/verify.ps1
+++ b/scripts/verify.ps1
@@ -25,3 +25,13 @@ if ($scriptNames -contains "build") {
         throw "npm run build failed with exit code $LASTEXITCODE."
     }
 }
+
+$nativeProjectPath = Join-Path $PSScriptRoot "..\native-gateway\D2Wealth.Gateway.Win\D2Wealth.Gateway.Win.csproj"
+$isWindowsHost = [System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform([System.Runtime.InteropServices.OSPlatform]::Windows)
+if ($isWindowsHost -and (Test-Path -LiteralPath $nativeProjectPath)) {
+    Write-Host "Running: dotnet build $nativeProjectPath -c Release"
+    dotnet build $nativeProjectPath -c Release
+    if ($LASTEXITCODE -ne 0) {
+        throw "dotnet build failed with exit code $LASTEXITCODE."
+    }
+}


### PR DESCRIPTION
## Summary
- Implement PRD task: Ship a Windows native client app that uses Discord auth and manages sync lifecycle.

## Tracking
- Closes #61
- Local verification: `.\\scripts\\verify.ps1`
- Merge rule: resolve GitHub review findings before merge