### PR TITLE
Fix production pairing backend origin

### DIFF
--- a/backend/server.mjs
+++ b/backend/server.mjs
@@ -175,6 +175,21 @@ const sessionCookie = (sessionId) =>
 
 const clearSessionCookie = () => `${COOKIE_NAME}=; HttpOnly; Path=/; SameSite=Lax; Max-Age=0${COOKIE_SECURE ? "; Secure" : ""}`;
 
+const forwardedProto = (request) => {
+  const raw = String(request.headers["x-forwarded-proto"] ?? "").trim();
+  if (!raw) {
+    return null;
+  }
+
+  return raw.split(",")[0]?.trim() || null;
+};
+
+const requestOrigin = (request, url) => {
+  const host = request.headers.host || `${HOST}:${PORT}`;
+  const protocol = forwardedProto(request) || url.protocol.replace(/:$/, "");
+  return `${protocol}://${host}`;
+};
+
 const sessionForRequest = (request) => {
   const cookies = parseCookies(request);
   const sessionId = cookies[COOKIE_NAME];
@@ -465,10 +480,10 @@ export const createBackendServer = () => http.createServer(async (request, respo
       const payload = JSON.parse(await readBody(request));
       const clientId = String(payload.clientId ?? "gateway").trim() || "gateway";
       const created = createGatewayPairing({ clientId });
-      const backendHost = request.headers.host || `${HOST}:${PORT}`;
+      const backendOrigin = requestOrigin(request, url);
       const pairReturnUrl = new URL(`${APP_REDIRECT_URI.replace(/\/+$/, "")}/`);
       pairReturnUrl.searchParams.set("pair", created.id);
-      pairReturnUrl.searchParams.set("backend", `${url.protocol}//${backendHost}`);
+      pairReturnUrl.searchParams.set("backend", backendOrigin);
       sendJson(request, response, 200, {
         pairingId: created.id,
         pairingSecret: created.pairingSecret,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -134,6 +134,23 @@ const deriveGatewayUrl = () => {
   return "http://127.0.0.1:3187";
 };
 
+const normalizeBackendUrl = (value: string, location: Location) => {
+  const fallback = value.trim();
+  if (!fallback) {
+    return fallback;
+  }
+
+  try {
+    const url = new URL(fallback, location.origin);
+    if (location.protocol === "https:" && url.protocol === "http:" && url.host === location.host) {
+      url.protocol = "https:";
+    }
+    return url.toString().replace(/\/+$/, "");
+  } catch {
+    return fallback.replace(/\/+$/, "");
+  }
+};
+
 const deriveBackendConfig = () => {
   if (typeof window === "undefined") {
     return { backendUrl: "", accountId: "" };
@@ -144,7 +161,10 @@ const deriveBackendConfig = () => {
     window.location.hostname === "localhost" || window.location.hostname === "127.0.0.1"
       ? "http://127.0.0.1:3197"
       : window.location.origin;
-  const backendUrl = params.get("backend") || window.localStorage.getItem(BACKEND_URL_KEY) || defaultBackendUrl;
+  const backendUrl = normalizeBackendUrl(
+    params.get("backend") || window.localStorage.getItem(BACKEND_URL_KEY) || defaultBackendUrl,
+    window.location,
+  );
   const accountId = params.get("account") || window.localStorage.getItem(ACCOUNT_ID_KEY) || "";
   return { backendUrl, accountId };
 };

--- a/test/backend-gateway.integration.test.mjs
+++ b/test/backend-gateway.integration.test.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import fs from "node:fs";
+import http from "node:http";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -295,6 +296,53 @@ test("pairing issues a token only after approval and consumes the pairing on fir
   );
   assert.equal(consumedClaimResponse.status, 410);
   assert.equal(consumedClaim.status, "consumed");
+});
+
+test("pairing URL uses the forwarded public https origin for browser return flow", async (t) => {
+  const ctx = await loadIntegrationContext("public-origin");
+  t.after(ctx.close);
+
+  const backendUrl = new URL(ctx.backendBaseUrl);
+  const payload = JSON.stringify({ clientId: "desktop-public-origin" });
+  const responseText = await new Promise((resolve, reject) => {
+    const request = http.request({
+      protocol: backendUrl.protocol,
+      hostname: backendUrl.hostname,
+      port: backendUrl.port,
+      path: "/api/gateway/pairing-sessions",
+      method: "POST",
+      headers: {
+        host: "d2r.bjav.io",
+        "x-forwarded-proto": "https",
+        "content-type": "application/json",
+        "content-length": Buffer.byteLength(payload),
+      },
+    }, (response) => {
+      let body = "";
+      response.setEncoding("utf8");
+      response.on("data", (chunk) => {
+        body += chunk;
+      });
+      response.on("end", () => {
+        try {
+          assert.equal(response.statusCode, 200);
+          resolve(body);
+        } catch (error) {
+          reject(error);
+        }
+      });
+    });
+
+    request.on("error", reject);
+    request.write(payload);
+    request.end();
+  });
+
+  const payloadJson = JSON.parse(responseText);
+  const pairingUrl = new URL(payloadJson.pairingUrl);
+  const returnTo = new URL(pairingUrl.searchParams.get("returnTo"));
+
+  assert.equal(returnTo.searchParams.get("backend"), "https://d2r.bjav.io");
 });
 
 test("gateway status summary reports explicit save, pairing, sync, and last-error states", async () => {


### PR DESCRIPTION
Closes #66

## What changed
- build pairing return URLs from forwarded public origin behind nginx
- normalize same-host http backend URLs to https in the web app
- add integration coverage for proxy-origin pairing flow

## Verification
- powershell -ExecutionPolicy Bypass -File .\\scripts\\verify.ps1
