### PR TITLE
Fix loose rune valuation and trim dashboard noise

### DIFF
--- a/gateway/report.mjs
+++ b/gateway/report.mjs
@@ -244,7 +244,7 @@ const stackQuantity = (item) => {
   }
 
   if (isMaterialLikeToken(item)) {
-    return Math.max(0, item.amount_in_shared_stash);
+    return item.amount_in_shared_stash > 0 ? item.amount_in_shared_stash : inventoryQuantity;
   }
 
   return inventoryQuantity;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "d2-wealth",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "d2-wealth",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "hasInstallScript": true,
       "dependencies": {
         "@d2runewizard/d2s": "^2.0.130",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d2-wealth",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Windows tray gateway for the D2 Wealth offline account tracker.",
   "author": "OpenAI Codex",
   "private": true,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1064,9 +1064,7 @@ export default function App() {
             <StatCard label="Personal Stash" value={formatHr(characterStashHrFromReport(report))} />
             <StatCard label="Shared Stashes" value={formatHr(report?.sharedHr ?? 0)} />
           </section>
-          <p className="stats-note">
-            Total HR = equipped gear + inventory + personal stash + shared stash. Unmatched and low-confidence items stay excluded below.
-          </p>
+          <p className="stats-note">Total HR = equipped gear + inventory + personal stash + shared stash.</p>
 
           <section className="dashboard-grid">
             <div className="main-column">
@@ -1116,8 +1114,6 @@ export default function App() {
               </section>
             </aside>
           </section>
-
-          <ValuationWarningsPanel report={report} />
 
           <section className="panel footnote-panel">
             <div className="panel-header">

--- a/src/lib/d2.ts
+++ b/src/lib/d2.ts
@@ -19,6 +19,8 @@ type D2Item = {
   ethereal?: number;
   total_nr_of_sockets?: number;
   socketed_items?: D2Item[];
+  quantity?: number;
+  amount_in_shared_stash?: number;
 };
 
 type CharacterData = {
@@ -226,6 +228,42 @@ const toWarningEntry = (item: ValuedItem) => ({
   includedInTotal: false as const,
 });
 
+const isMaterialLikeToken = (item: D2Item) => {
+  const name = displayName(item);
+  const normalized = normalizeMarketName(name);
+  const type = String(item.type ?? "");
+  return (
+    /^r\d{2}$/i.test(type) ||
+    /^pk[123]$/i.test(type) ||
+    /^ce[hdbf]$/i.test(type) ||
+    /^xa\d$/i.test(type) ||
+    normalized.includes("rune") ||
+    normalized.includes("key of") ||
+    normalized.includes("essence") ||
+    normalized.includes("worldstone shard") ||
+    normalized.includes("jewel") ||
+    normalized.includes("topaz") ||
+    normalized.includes("emerald") ||
+    normalized.includes("sapphire") ||
+    normalized.includes("ruby") ||
+    normalized.includes("amethyst") ||
+    normalized.includes("skull")
+  );
+};
+
+const stackQuantity = (item: D2Item) => {
+  const inventoryQuantity = typeof item.quantity === "number" && item.quantity > 0 ? item.quantity : 1;
+  if (typeof item.amount_in_shared_stash !== "number") {
+    return inventoryQuantity;
+  }
+
+  if (isMaterialLikeToken(item)) {
+    return item.amount_in_shared_stash > 0 ? item.amount_in_shared_stash : inventoryQuantity;
+  }
+
+  return inventoryQuantity;
+};
+
 const collectWarnings = (
   items: ValuedItem[],
   valuationWarnings: WealthReport["valuationWarnings"]["items"],
@@ -237,10 +275,13 @@ const collectWarnings = (
 };
 
 const evaluateItem = (item: D2Item, owner: string, location: ItemLocation, source: string): ValuedItem => {
+  const quantity = stackQuantity(item);
+
   if (isLowConfidenceStoredAccessory(item, location)) {
     return {
       id: `${owner}-${source}-${displayName(item)}`,
       name: displayName(item),
+      quantity,
       owner,
       location,
       source,
@@ -254,6 +295,7 @@ const evaluateItem = (item: D2Item, owner: string, location: ItemLocation, sourc
     return {
       id: `${owner}-${source}-${displayName(item)}`,
       name: displayName(item),
+      quantity,
       owner,
       location,
       source,
@@ -270,6 +312,7 @@ const evaluateItem = (item: D2Item, owner: string, location: ItemLocation, sourc
     return {
       id: `${owner}-${source}-${displayName(item)}`,
       name: resolvedRuneword,
+      quantity,
       owner,
       location,
       source,
@@ -284,10 +327,11 @@ const evaluateItem = (item: D2Item, owner: string, location: ItemLocation, sourc
     return {
       id: `${owner}-${source}-${displayName(item)}`,
       name: displayName(item),
+      quantity,
       owner,
       location,
       source,
-      valueHr: tokenMatch.valueHr,
+      valueHr: tokenMatch.valueHr * quantity,
       matchedBy: "token",
       valueSource: tokenMatch.kind === "rune" ? liveRuneValueSource() : workbookValueSource("Workbook Token Market"),
     };
@@ -298,6 +342,7 @@ const evaluateItem = (item: D2Item, owner: string, location: ItemLocation, sourc
     return {
       id: `${owner}-${source}-${displayName(item)}`,
       name: displayName(item),
+      quantity,
       owner,
       location,
       source,
@@ -316,6 +361,7 @@ const evaluateItem = (item: D2Item, owner: string, location: ItemLocation, sourc
     return {
       id: `${owner}-${source}-${displayName(item)}`,
       name: displayName(item),
+      quantity,
       owner,
       location,
       source,
@@ -328,6 +374,7 @@ const evaluateItem = (item: D2Item, owner: string, location: ItemLocation, sourc
   return {
     id: `${owner}-${source}-${displayName(item)}`,
     name: displayName(item),
+    quantity,
     owner,
     location,
     source,
@@ -341,9 +388,13 @@ const gatherRuneCounts = (items: D2Item[], counts: Map<string, { count: number; 
   for (const item of items) {
     const token = matchTokenValue(item);
     if (token?.kind === "rune") {
+      const quantity = stackQuantity(item);
+      if (quantity <= 0) {
+        continue;
+      }
       const current = counts.get(token.name) ?? { count: 0, looseCount: 0 };
-      current.count += 1;
-      current.looseCount += looseOnly ? 1 : 0;
+      current.count += quantity;
+      current.looseCount += looseOnly ? quantity : 0;
       counts.set(token.name, current);
     }
 

--- a/test/fixtures/parser-account.fixture.json
+++ b/test/fixtures/parser-account.fixture.json
@@ -75,13 +75,13 @@
   "expectedReport": {
     "importedAt": "2026-03-29T16:00:00.000Z",
     "saveSetId": "15304a871e250089e79f0bbe06f82019b57c60c1fd2ec7cc0a8ef72b2ecbe8e7",
-    "totalHr": 3.125,
-    "runeHr": 3,
+    "totalHr": 4.125,
+    "runeHr": 4,
     "equippedHr": 0.0938,
     "inventoryHr": 0,
     "characterStashHr": 0.0313,
     "stashHr": 0.0313,
-    "sharedHr": 3,
+    "sharedHr": 4,
     "characters": [
       {
         "name": "FixtureSorc",
@@ -101,6 +101,16 @@
         "count": 2,
         "looseCount": 2,
         "totalHr": 2.5,
+        "valueSource": {
+          "type": "rune-market",
+          "label": "Live Rune Market"
+        }
+      },
+      {
+        "name": "Ber",
+        "count": 1,
+        "looseCount": 1,
+        "totalHr": 1,
         "valueSource": {
           "type": "rune-market",
           "label": "Live Rune Market"
@@ -148,6 +158,20 @@
         "location": "shared-stash",
         "source": "SharedStashSoftCoreV2.d2i materials 1",
         "valueHr": 2.5,
+        "matchedBy": "token",
+        "valueSource": {
+          "type": "rune-market",
+          "label": "Live Rune Market"
+        }
+      },
+      {
+        "id": "SharedStashSoftCoreV2.d2i-SharedStashSoftCoreV2.d2i materials 3-Ber Rune",
+        "name": "Ber Rune",
+        "quantity": 1,
+        "owner": "SharedStashSoftCoreV2.d2i",
+        "location": "shared-stash",
+        "source": "SharedStashSoftCoreV2.d2i materials 3",
+        "valueHr": 1,
         "matchedBy": "token",
         "valueSource": {
           "type": "rune-market",
@@ -257,13 +281,13 @@
     },
     "snapshot": {
       "importedAt": "2026-03-29T16:00:00.000Z",
-      "totalHr": 3.125,
-      "runeHr": 3,
+      "totalHr": 4.125,
+      "runeHr": 4,
       "equippedHr": 0.0938,
       "inventoryHr": 0,
       "characterStashHr": 0.0313,
       "stashHr": 0.0313,
-      "sharedHr": 3,
+      "sharedHr": 4,
       "characterCount": 1
     }
   }

--- a/test/fixtures/real-save-account/parsed-save.fixture.json
+++ b/test/fixtures/real-save-account/parsed-save.fixture.json
@@ -770,6 +770,16 @@
           "equippedSlot": null
         },
         {
+          "name": "Gul Rune",
+          "type": "r25",
+          "baseName": "Gul Rune",
+          "location": "shared-stash",
+          "quantity": 1,
+          "x": 0,
+          "y": 0,
+          "equippedSlot": null
+        },
+        {
           "name": "Hel Rune",
           "type": "r15",
           "baseName": "Hel Rune",
@@ -846,6 +856,16 @@
           "location": "shared-stash",
           "quantity": 3,
           "x": 3,
+          "y": 0,
+          "equippedSlot": null
+        },
+        {
+          "name": "Lem Rune",
+          "type": "r20",
+          "baseName": "Lem Rune",
+          "location": "shared-stash",
+          "quantity": 1,
+          "x": 0,
           "y": 0,
           "equippedSlot": null
         },

--- a/test/offline-save-parser.test.mjs
+++ b/test/offline-save-parser.test.mjs
@@ -22,7 +22,7 @@ test("real offline save fixtures parse character and shared stash data accuratel
   assert.equal(parsed.stashes.length, 1);
   assert.equal(parsed.stashes[0].kind, "shared");
   assert.equal(parsed.stashes[0].pages[0].items.length, 10);
-  assert.equal(parsed.stashes[0].materialItems.length, 47);
+  assert.equal(parsed.stashes[0].materialItems.length, 49);
 });
 
 test("real offline save fixture parsing stays deterministic across repeated runs", async () => {

--- a/test/parser-fixtures.test.mjs
+++ b/test/parser-fixtures.test.mjs
@@ -604,7 +604,7 @@ test("account totals reconcile to equipped, inventory, stash, shared stash, and 
   assert.ok(report.runeSummary.every((entry) => entry.count > 0));
   assert.deepEqual(
     report.runeSummary.map((entry) => entry.name),
-    ["Jah", "Ist"],
+    ["Jah", "Ber", "Ist"],
   );
 });
 
@@ -793,4 +793,23 @@ test("pricing contract surfaces explicit source labels for rune, workbook, deriv
   assert.ok(unresolvedItem);
   assert.equal(unresolvedItem.valueSource.type, "unresolved");
   assert.equal(unresolvedItem.valueSource.label, "Unresolved Market Value");
+});
+
+test("loose runes keep a quantity of one when shared-stash counters are zero", () => {
+  const berRune = evaluateItem(
+    makeValueTestItem({
+      type: "r30",
+      type_name: "Ber Rune",
+      quantity: 0,
+      amount_in_shared_stash: 0,
+    }),
+    "ContractTester",
+    "inventory",
+    "ContractTester carry 99",
+  );
+
+  assert.equal(berRune.quantity, 1);
+  assert.equal(berRune.matchedBy, "token");
+  assert.equal(berRune.valueSource.type, "rune-market");
+  assert.equal(berRune.valueHr, marketData.runeValues.Ber);
 });


### PR DESCRIPTION
Closes #68

## What changed
- treat loose runes as quantity 1 when shared-stash counters are zero
- update parser and report fixtures to reflect corrected rune totals
- remove the main valuation warnings panel from the dashboard
- bump gateway version to 0.1.2 for MSI publication

## Verification
- powershell -ExecutionPolicy Bypass -File .\\scripts\\verify.ps1
