### PR TITLE
Serve fresh frontend HTML after deploys

### DIFF
--- a/deploy/nginx/d2r.bjav.io.conf
+++ b/deploy/nginx/d2r.bjav.io.conf
@@ -42,7 +42,18 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
+    location /assets/ {
+        expires 1y;
+        add_header Cache-Control "public, max-age=31536000, immutable" always;
+        try_files $uri =404;
+    }
+
+    location = /index.html {
+        add_header Cache-Control "no-store, no-cache, must-revalidate" always;
+    }
+
     location / {
+        add_header Cache-Control "no-store, no-cache, must-revalidate" always;
         try_files $uri $uri/ /index.html;
     }
 }


### PR DESCRIPTION
## Summary\n- prevent browsers from caching index.html across deploys\n- keep hashed asset bundles cached aggressively\n- reduce stale frontend state after production releases\n\nCloses #70