### PR TITLE
Manage d2r.bjav.io HTTPS in repo nginx config

### DIFF
--- a/deploy/nginx/d2r.bjav.io.conf
+++ b/deploy/nginx/d2r.bjav.io.conf
@@ -3,6 +3,22 @@ server {
     listen [::]:80;
     server_name d2r.bjav.io;
 
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    http2 on;
+    server_name d2r.bjav.io;
+
+    ssl_certificate /etc/letsencrypt/live/d2r.bjav.io/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/d2r.bjav.io/privkey.pem;
+
     root /srv/d2-wealth/current/dist;
     index index.html;
 


### PR DESCRIPTION
## Summary\n- make the repo-managed nginx site own the 443 vhost for d2r.bjav.io\n- redirect plain HTTP to HTTPS\n- use the standard Let's Encrypt certificate paths for the domain\n\nCloses #76