### PR TITLE
Use compatible nginx HTTP/2 syntax for d2r vhost

### DIFF
--- a/deploy/nginx/d2r.bjav.io.conf
+++ b/deploy/nginx/d2r.bjav.io.conf
@@ -11,9 +11,8 @@ server {
 }
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
-    http2 on;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
     server_name d2r.bjav.io;
 
     ssl_certificate /etc/letsencrypt/live/d2r.bjav.io/fullchain.pem;


### PR DESCRIPTION
## Summary\n- switch the d2r.bjav.io HTTPS vhost to nginx's supported HTTP/2 listen syntax\n- unblock loading the repo-managed 443 config on production\n\nCloses #78