### PR TITLE
Fix snapshot history retention and roster UI

### DIFF
--- a/backend/db.mjs
+++ b/backend/db.mjs
@@ -662,16 +662,6 @@ export const ingestAccountReport = ({ accountId, gatewayTokenId, clientId, repor
     const saveSetId = resolved.saveSetId;
     latestAccountId = resolved.accountId;
 
-    const existingLatest = db.prepare("SELECT save_set_id FROM account_latest WHERE account_id = ?").get(latestAccountId);
-    const saveSetChanged =
-      Boolean(saveSetId) &&
-      Boolean(existingLatest) &&
-      String(existingLatest.save_set_id ?? "") !== saveSetId;
-
-    if (saveSetChanged) {
-      db.prepare("DELETE FROM account_history WHERE account_id = ?").run(latestAccountId);
-    }
-
     db.prepare(
       "INSERT OR REPLACE INTO account_latest (account_id, client_id, received_at, save_set_id, report_json) VALUES (?, ?, ?, ?, ?)",
     ).run(latestAccountId, clientId, timestamp, saveSetId, JSON.stringify(report));

--- a/gateway/settings.mjs
+++ b/gateway/settings.mjs
@@ -27,7 +27,7 @@ export const DEFAULT_SETTINGS_PATH = process.env.D2_GATEWAY_SETTINGS_PATH
 
 const sanitizePort = (value) => {
   const port = Number(value);
-  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+  if (!Number.isInteger(port) || port < 0 || port > 65535) {
     return DEFAULT_GATEWAY_SETTINGS.port;
   }
   return port;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -188,7 +188,6 @@ const derivePendingPairingId = () => {
 };
 
 const portraitForClass = (className: string) => classPortraits[className.toLowerCase()] ?? sorceressPortrait;
-const warningKindLabel = (kind: "unresolved" | "ambiguous") => (kind === "ambiguous" ? "Low confidence" : "Unmatched");
 const rulesetClass = (ruleset: "Classic" | "LoD" | "ROTW") => {
   if (ruleset === "ROTW") {
     return "ruleset-rotw";
@@ -442,48 +441,6 @@ function TradeBreakdown(props: { valueHr: number }) {
   );
 }
 
-function ValuationWarningsPanel(props: { report: WealthReport | null }) {
-  const warnings = props.report?.valuationWarnings;
-  const visibleWarnings = warnings?.items.slice(0, 8) ?? [];
-
-  return (
-    <section className="panel warning-panel">
-      <div className="panel-header">
-        <h3>Valuation Warnings</h3>
-        <span>{warnings?.totalCount ?? 0} excluded items</span>
-      </div>
-      {!warnings?.totalCount ? (
-        <p className="empty-state">All parsed items matched a trusted valuation path.</p>
-      ) : (
-        <>
-          <p className="warning-summary">
-            {warnings.totalCount} items are excluded from HR totals: {warnings.unresolvedCount} unmatched and {warnings.ambiguousCount} low-confidence.
-          </p>
-          <div className="table">
-            {visibleWarnings.map((warning) => (
-              <div key={`${warning.owner}-${warning.source}-${warning.name}`} className="table-row">
-                <div>
-                  <strong>{warning.name}</strong>
-                  <span>
-                    {warning.owner} • {warning.source ?? warning.location}
-                  </span>
-                </div>
-                <div className="warning-meta">
-                  <span className={`warning-pill ${warning.kind}`}>{warningKindLabel(warning.kind)}</span>
-                  <span>{warning.valueSource.detail ?? warning.valueSource.label}</span>
-                </div>
-              </div>
-            ))}
-          </div>
-          {warnings.totalCount > visibleWarnings.length ? (
-            <p className="warning-summary">Showing {visibleWarnings.length} of {warnings.totalCount} excluded items.</p>
-          ) : null}
-        </>
-      )}
-    </section>
-  );
-}
-
 function HistoryChart(props: { data: WealthSnapshot[] }) {
   if (props.data.length === 0) {
     return <p className="empty-state">No snapshots yet. Import a save set to start the timeline.</p>;
@@ -633,6 +590,7 @@ export default function App() {
   const reportRef = useRef<WealthReport | null>(null);
   const selectedAccountRef = useRef(selectedAccountId);
   const deferredHistory = useDeferredValue(history);
+  const selectedAccount = accounts.find((account) => account.id === selectedAccountId) ?? accounts[0] ?? null;
 
   useEffect(() => {
     setHistory(loadHistory());
@@ -909,7 +867,10 @@ export default function App() {
           setAccounts(mePayload.accounts);
           setAuthRequired(false);
 
-          const nextAccountId = mePayload.accounts[0]?.id || "";
+          const nextAccountId =
+            mePayload.accounts.find((account) => account.id === selectedAccountRef.current)?.id
+            ?? mePayload.accounts[0]?.id
+            ?? "";
           if (selectedAccountRef.current !== nextAccountId) {
             setSelectedAccountId(nextAccountId);
           }
@@ -1012,7 +973,17 @@ export default function App() {
                   <span className="gateway-status status-connected">{user?.username}</span>
                 </div>
                 <div className="account-controls">
-                  <span>{accounts[0]?.name ?? "Discord Account"}</span>
+                  {accounts.length > 1 ? (
+                    <select value={selectedAccountId} onChange={(event) => setSelectedAccountId(event.target.value)}>
+                      {accounts.map((account) => (
+                        <option key={account.id} value={account.id}>
+                          {account.name}
+                        </option>
+                      ))}
+                    </select>
+                  ) : (
+                    <span>{selectedAccount?.name ?? "Discord Account"}</span>
+                  )}
                   <button type="button" onClick={logout}>
                     Log Out
                   </button>
@@ -1098,12 +1069,7 @@ export default function App() {
                         </div>
                         <div className="roster-values">
                           <b>{formatHr(totalHrForCharacter(character))}</b>
-                          <span className="roster-total-label">total</span>
-                          <div className="roster-breakdown">
-                            <span>Eq {formatHr(character.equippedHr)}</span>
-                            <span>Inv {formatHr(inventoryHrForCharacter(character))}</span>
-                            <span>Stash {formatHr(characterStashHrForCharacter(character))}</span>
-                          </div>
+                          <span>{formatHr(character.equippedHr)} equipped</span>
                         </div>
                       </article>
                     ))}

--- a/test/backend-gateway.integration.test.mjs
+++ b/test/backend-gateway.integration.test.mjs
@@ -656,6 +656,63 @@ test("gateway sync covers token-based ingest, latest/history reads, and disconne
   assert.match(loggedOutReadBody.error, /Authentication required/);
 });
 
+test("gateway sync preserves history even if the latest save-set marker drifts", async (t) => {
+  const ctx = await loadIntegrationContext("history-preserve");
+  t.after(ctx.close);
+
+  const pairing = await createPairing(ctx.backendBaseUrl, "desktop-history");
+  await approvePairing(ctx.backendBaseUrl, pairing.pairingId, ctx.sessionCookie);
+  const { response: claimResponse, body: claimed } = await claimPairing(
+    ctx.backendBaseUrl,
+    pairing.pairingId,
+    pairing.pairingSecret,
+  );
+  assert.equal(claimResponse.status, 200);
+  assert.equal(claimed.status, "approved");
+
+  const saveDir = path.join(ctx.tempRoot, "history-preserve");
+  fs.mkdirSync(saveDir, { recursive: true });
+  fs.writeFileSync(path.join(saveDir, "hero.d2s"), "fixture", "utf8");
+
+  const service = new GatewayService({
+    settings: {
+      host: "127.0.0.1",
+      port: 3188,
+      saveDir,
+      autoStart: false,
+      dashboardUrl: "http://127.0.0.1:4173",
+      backendUrl: ctx.backendBaseUrl,
+      accountId: ctx.account.id,
+      clientId: claimed.clientId,
+      syncToken: claimed.gatewayToken,
+    },
+  });
+
+  let report = createReport("HistoryA", 11.5, "2026-03-29T13:00:00.000Z", "save-set-alpha");
+  service.buildReport = async () => report;
+  await service.syncToBackend();
+
+  ctx.db.getDatabase().prepare("UPDATE account_latest SET save_set_id = ? WHERE account_id = ?").run("save-set-drifted", ctx.account.id);
+
+  report = createReport("HistoryB", 14.25, "2026-03-29T13:05:00.000Z", "save-set-alpha");
+  await service.syncToBackend();
+
+  const { response: historyResponse, body: historyBody } = await fetchJson(
+    `${ctx.backendBaseUrl}/api/accounts/${encodeURIComponent(ctx.account.id)}/history`,
+    {
+      headers: { Cookie: ctx.sessionCookie },
+    },
+  );
+  assert.equal(historyResponse.status, 200);
+  assert.deepEqual(
+    historyBody.history.map((entry) => ({ totalHr: entry.totalHr, capturedAt: entry.capturedAt })),
+    [
+      { totalHr: 11.5, capturedAt: "2026-03-29T13:00:00.000Z" },
+      { totalHr: 14.25, capturedAt: "2026-03-29T13:05:00.000Z" },
+    ],
+  );
+});
+
 test("backend stores parsed save data per save-set account and updates rows on re-sync", async (t) => {
   const ctx = await loadIntegrationContext("save-set-accounts");
   t.after(ctx.close);


### PR DESCRIPTION
## Summary
- stop deleting account history when the latest save-set marker drifts
- keep the selected backend account stable instead of snapping to the first account on every poll
- simplify the character roster HR copy and allow ephemeral port 0 in gateway settings for reliable local integration tests

## Verification
- powershell -ExecutionPolicy Bypass -File .\\scripts\\verify.ps1